### PR TITLE
Add proper error handling for GPU packets

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -3718,10 +3718,13 @@ GDBRemoteCommunicationServerLLGS::Handle_jGPUPluginBreakpointHit(
 
   for (auto &plugin_up: m_plugins) {
     if (plugin_up->GetPluginName() == args->plugin_name) {
-      GPUPluginBreakpointHitResponse bp_response = 
+      Expected<GPUPluginBreakpointHitResponse> bp_response = 
           plugin_up->BreakpointWasHit(*args);
+      if (!bp_response)
+        return SendErrorResponse(bp_response.takeError());
+        
       StreamGDBRemote response;
-      response.PutAsJSON(bp_response, /*hex_ascii=*/false);
+      response.PutAsJSON(*bp_response, /*hex_ascii=*/false);
       return SendPacketNoLock(response.GetString());
     }
   }

--- a/lldb/source/Plugins/Process/gdb-remote/LLDBServerPlugin.h
+++ b/lldb/source/Plugins/Process/gdb-remote/LLDBServerPlugin.h
@@ -16,16 +16,16 @@
 #include "llvm/Support/JSON.h"
 
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <stdint.h>
 #include <string>
-#include <mutex>
 
 namespace lldb_private {
 
 namespace process_gdb_remote {
-  class GDBRemoteCommunicationServerLLGS;
-}
+class GDBRemoteCommunicationServerLLGS;
+} // namespace process_gdb_remote
 
 namespace lldb_server {
 
@@ -125,11 +125,11 @@ public:
   /// calling m_process.SetBreakpoint(...) to help implement funcionality,
   /// such as dynamic library loading in GPUs or to synchronize in any other
   /// way with the native process.
-  virtual GPUPluginBreakpointHitResponse
+  virtual llvm::Expected<GPUPluginBreakpointHitResponse>
   BreakpointWasHit(GPUPluginBreakpointHitArgs &args) = 0;
 
-  protected:
-    std::mutex m_connect_mutex;
+protected:
+  std::mutex m_connect_mutex;
 };
 
 } // namespace lldb_server

--- a/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
@@ -181,7 +181,7 @@ std::optional<GPUActions> LLDBServerPluginMockGPU::NativeProcessIsStopping() {
   return std::nullopt;
 }
 
-GPUPluginBreakpointHitResponse 
+llvm::Expected<GPUPluginBreakpointHitResponse>
 LLDBServerPluginMockGPU::BreakpointWasHit(GPUPluginBreakpointHitArgs &args) {
   Log *log = GetLog(GDBRLog::Plugin);
   std::string json_string;

--- a/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.h
+++ b/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.h
@@ -49,13 +49,13 @@ $ ./bin/lldb a.out -o 'b /Break here/ -o run
 */
 // If the above code is run, you will be stopped at the breakpoint and the Mock
 // GPU target will be selected. Try doing a "reg read --all" to see the state
-// of the GPU registers. Then you can select the native process target with 
+// of the GPU registers. Then you can select the native process target with
 // "target select 0" and issue commands to the native process, and then select
 // the GPU target with "target select 1" and issue commands to the GPU target.
 
 namespace lldb_private {
-  
-  class TCPSocket;
+
+class TCPSocket;
 
 namespace lldb_server {
 
@@ -67,8 +67,8 @@ public:
   int GetEventFileDescriptorAtIndex(size_t idx) override;
   bool HandleEventFileDescriptorEvent(int fd) override;
   GPUActions GetInitializeActions() override;
-  std::optional<struct GPUActions> NativeProcessIsStopping() override;  
-  GPUPluginBreakpointHitResponse 
+  std::optional<struct GPUActions> NativeProcessIsStopping() override;
+  llvm::Expected<GPUPluginBreakpointHitResponse>
   BreakpointWasHit(GPUPluginBreakpointHitArgs &args) override;
 
 private:


### PR DESCRIPTION
Server errors were being disposed right after parsing in the client. Instead, now they are displayed to the user. This helps a lot with development.
I'm using Debugger::Report error for this because they are non-blocking issues, as the CPU target can keep being debugged, but the user needs to know that the GPU plugin couldn't be initialized and they can report the issue if they want it.