### PR TITLE
[To upstream] Add a name to server comm channels and include them in …

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteClientBase.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteClientBase.cpp
@@ -32,7 +32,7 @@ static const seconds kWakeupInterval(5);
 GDBRemoteClientBase::ContinueDelegate::~ContinueDelegate() = default;
 
 GDBRemoteClientBase::GDBRemoteClientBase(const char *comm_name)
-    : GDBRemoteCommunication(), Broadcaster(nullptr, comm_name),
+    : GDBRemoteCommunication(comm_name), Broadcaster(nullptr, comm_name),
       m_async_count(0), m_is_running(false), m_should_stop(false) {}
 
 StateType GDBRemoteClientBase::SendContinuePacketAndWaitForResponse(

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
@@ -117,7 +117,9 @@ public:
     bool m_timeout_modified;
   };
 
-  GDBRemoteCommunication();
+  /// \param[in] name
+  ///     The name of the communication channel.
+  GDBRemoteCommunication(llvm::StringRef name);
 
   ~GDBRemoteCommunication() override;
 
@@ -226,6 +228,8 @@ private:
 
   HostThread m_listen_thread;
   std::string m_listen_url;
+
+  std::string m_name;
 
 #if defined(HAVE_LIBCOMPRESSION)
   CompressionType m_decompression_scratch_type = CompressionType::None;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServer.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServer.cpp
@@ -24,8 +24,8 @@ using namespace lldb_private;
 using namespace lldb_private::process_gdb_remote;
 using namespace llvm;
 
-GDBRemoteCommunicationServer::GDBRemoteCommunicationServer()
-    : GDBRemoteCommunication(), m_exit_now(false) {
+GDBRemoteCommunicationServer::GDBRemoteCommunicationServer(llvm::StringRef name)
+    : GDBRemoteCommunication(name), m_exit_now(false) {
   RegisterPacketHandler(
       StringExtractorGDBRemote::eServerPacketType_QEnableErrorStrings,
       [this](StringExtractorGDBRemote packet, Status &error, bool &interrupt,

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServer.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServer.h
@@ -31,7 +31,9 @@ public:
       std::function<PacketResult(StringExtractorGDBRemote &packet,
                                  Status &error, bool &interrupt, bool &quit)>;
 
-  GDBRemoteCommunicationServer();
+  /// \param[in] name
+  ///     The name of the communication channel.
+  GDBRemoteCommunicationServer(llvm::StringRef name);
 
   ~GDBRemoteCommunicationServer() override;
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
@@ -58,8 +58,9 @@ const static uint32_t g_default_packet_timeout_sec = 0; // not specified
 #endif
 
 // GDBRemoteCommunicationServerCommon constructor
-GDBRemoteCommunicationServerCommon::GDBRemoteCommunicationServerCommon()
-    : GDBRemoteCommunicationServer(), m_process_launch_info(),
+GDBRemoteCommunicationServerCommon::GDBRemoteCommunicationServerCommon(
+    llvm::StringRef name)
+    : GDBRemoteCommunicationServer(name), m_process_launch_info(),
       m_process_launch_error(), m_proc_infos(), m_proc_infos_index(0) {
   RegisterMemberFunctionHandler(StringExtractorGDBRemote::eServerPacketType_A,
                                 &GDBRemoteCommunicationServerCommon::Handle_A);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.h
@@ -25,7 +25,9 @@ class ProcessGDBRemote;
 
 class GDBRemoteCommunicationServerCommon : public GDBRemoteCommunicationServer {
 public:
-  GDBRemoteCommunicationServerCommon();
+  /// \param[in] name
+  ///     The name of the communication channel.
+  GDBRemoteCommunicationServerCommon(llvm::StringRef name);
 
   ~GDBRemoteCommunicationServerCommon() override;
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -72,8 +72,9 @@ enum GDBRemoteServerError {
 
 // GDBRemoteCommunicationServerLLGS constructor
 GDBRemoteCommunicationServerLLGS::GDBRemoteCommunicationServerLLGS(
-    MainLoop &mainloop, NativeProcessProtocol::Manager &process_manager)
-    : GDBRemoteCommunicationServerCommon(), m_mainloop(mainloop),
+    MainLoop &mainloop, NativeProcessProtocol::Manager &process_manager,
+    llvm::StringRef name)
+    : GDBRemoteCommunicationServerCommon(name), m_mainloop(mainloop),
       m_process_manager(process_manager), m_current_process(nullptr),
       m_continue_process(nullptr), m_stdio_communication() {
   RegisterPacketHandlers();

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
@@ -37,9 +37,15 @@ class GDBRemoteCommunicationServerLLGS
     : public GDBRemoteCommunicationServerCommon,
       public NativeProcessProtocol::NativeDelegate {
 public:
-  // Constructors and Destructors
+  /// \param[in] mainloop
+  ///     The main loop.
+  /// \param[in] process_manager
+  ///     The process manager.
+  /// \param[in] name
+  ///     The name of the communication channel.
   GDBRemoteCommunicationServerLLGS(
-      MainLoop &mainloop, NativeProcessProtocol::Manager &process_manager);
+      MainLoop &mainloop, NativeProcessProtocol::Manager &process_manager,
+      llvm::StringRef name);
 
   void SetLaunchInfo(const ProcessLaunchInfo &info);
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
@@ -47,8 +47,8 @@ using namespace lldb_private;
 // GDBRemoteCommunicationServerPlatform constructor
 GDBRemoteCommunicationServerPlatform::GDBRemoteCommunicationServerPlatform(
     const Socket::SocketProtocol socket_protocol, uint16_t gdbserver_port)
-    : GDBRemoteCommunicationServerCommon(), m_socket_protocol(socket_protocol),
-      m_gdbserver_port(gdbserver_port) {
+    : GDBRemoteCommunicationServerCommon("gdb-server-platform"),
+      m_socket_protocol(socket_protocol), m_gdbserver_port(gdbserver_port) {
 
   RegisterMemberFunctionHandler(
       StringExtractorGDBRemote::eServerPacketType_qC,

--- a/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
@@ -29,8 +29,8 @@ LLDBServerPluginMockGPU::LLDBServerPluginMockGPU(
   LLDBServerPlugin::GDBServer &native_process)
     : LLDBServerPlugin(native_process) {
   m_process_manager_up.reset(new ProcessMockGPU::Manager(m_main_loop));
-  m_gdb_server.reset(
-      new GDBRemoteCommunicationServerLLGS(m_main_loop, *m_process_manager_up));
+  m_gdb_server.reset(new GDBRemoteCommunicationServerLLGS(
+      m_main_loop, *m_process_manager_up, "mock-gpu.server"));
 
   Log *log = GetLog(GDBRLog::Plugin);
   LLDB_LOGF(log, "LLDBServerPluginMockGPU::LLDBServerPluginMockGPU() faking launch...");

--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -454,7 +454,7 @@ int main_gdbserver(int argc, char *argv[]) {
   }
 
   NativeProcessManager manager(mainloop);
-  GDBRemoteCommunicationServerLLGS gdb_server(mainloop, manager);
+  GDBRemoteCommunicationServerLLGS gdb_server(mainloop, manager, "gdb-server");
 
   // Install the mock GPU plugin.
   gdb_server.InstallPlugin(std::make_unique<LLDBServerPluginMockGPU>(gdb_server));


### PR DESCRIPTION
…the logs

This allows differenciating GPU and CPU gdb-remote logs emitted by the server.

E.g.
```
1749485814.359431028 [754988/755010] nvidia-gpu.server <  19> read packet: $QStartNoAckMode#b0
1749485814.359459400 [754988/755010] nvidia-gpu.server <   1> send packet: +

1749485813.658699989 [754988/754988] gdb-server <  29> read packet: $qXfer:auxv:read::0,131071#d7
1749485813.658788681 [754988/754988] gdb-server < 341> send packet: $l!
```