### PR TITLE
Check object offset in ModuleSpec matching

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1538,6 +1538,9 @@ bool Module::MatchesModuleSpec(const ModuleSpec &module_ref) {
   if (!FileSpec::Match(platform_file_spec, GetPlatformFileSpec()))
     return false;
 
+  if (m_object_offset != module_ref.GetObjectOffset())
+    return false;
+
   const ArchSpec &arch = module_ref.GetArchitecture();
   if (arch.IsValid()) {
     if (!m_arch.IsCompatibleMatch(arch))


### PR DESCRIPTION
This PR makes a minor change to check for object offset matching in ModuleSpec matching. 

Since AMD code object is embedded into host CPU object file, GPU module will have non-zero offset. This is required to support parsing AMD GPU module out of host ELF module.