### PR TITLE
Fix compile errors

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
@@ -12,9 +12,11 @@
 #include "GDBRemoteCommunicationHistory.h"
 #include "lldb/Core/Communication.h"
 #include "lldb/Host/Config.h"
+#include "lldb/Host/HostThread.h"
 #include "lldb/Host/Socket.h"
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/StringExtractorGDBRemote.h"
+#include <future>
 #include <mutex>
 #include <string>
 

--- a/lldb/tools/lldb-server/CMakeLists.txt
+++ b/lldb/tools/lldb-server/CMakeLists.txt
@@ -71,7 +71,6 @@ add_lldb_tool(lldb-server
       lldbPluginInstructionMIPS64
       lldbPluginInstructionRISCV
       ${LLDB_SYSTEM_LIBS}
-      lldbServerPluginInterface
       lldbServerPluginMockGPU
 )
 

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -256,7 +256,7 @@ void LLDBServerPluginAMDGPU::AcceptAndMainLoopThread(
 
   LLDB_LOGF(log, "%s initializing connection", __PRETTY_FUNCTION__);
   std::unique_ptr<Connection> connection_up(
-      new ConnectionFileDescriptor(socket));
+      new ConnectionFileDescriptor(std::unique_ptr<Socket>(socket)));
   m_gdb_server->InitializeConnection(std::move(connection_up));
   LLDB_LOGF(log, "%s running main loop", __PRETTY_FUNCTION__);
   m_main_loop_status = m_main_loop.Run();
@@ -310,7 +310,7 @@ LLDBServerPluginAMDGPU::CreateConnection() {
                         "LLDBServerPluginAMDGPU::AcceptAndMainLoopThread() "
                         "initializing connection");
               std::unique_ptr<Connection> connection_up(
-                  new ConnectionFileDescriptor(socket.release()));
+                  new ConnectionFileDescriptor(std::move(socket)));
               this->m_gdb_server->InitializeConnection(
                   std::move(connection_up));
               m_is_connected = true;

--- a/lldb/tools/lldb-server/Plugins/CMakeLists.txt
+++ b/lldb/tools/lldb-server/Plugins/CMakeLists.txt
@@ -1,5 +1,4 @@
 if(DEFINED ROCM_PATH AND EXISTS ${ROCM_PATH})
   add_subdirectory(AMDGPU)
-else()
-  add_subdirectory(MockGPU)
 endif()
+add_subdirectory(MockGPU)

--- a/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
@@ -116,7 +116,7 @@ void LLDBServerPluginMockGPU::AcceptAndMainLoopThread(
 
   LLDB_LOGF(log, "%s initializing connection", __PRETTY_FUNCTION__);
   std::unique_ptr<Connection> connection_up(
-      new ConnectionFileDescriptor(socket));
+      new ConnectionFileDescriptor(std::unique_ptr<Socket>(socket)));
   m_gdb_server->InitializeConnection(std::move(connection_up));
   LLDB_LOGF(log, "%s running main loop", __PRETTY_FUNCTION__);
   m_main_loop_status = m_main_loop.Run();


### PR DESCRIPTION
These started showing up after the rebase to llvm main branch. An upstream [change](https://github.com/llvm/llvm-project/commit/cf9546b826619890e965367a3e4d0da1991ba929) removed the ConnectionFileDescriptor constructor that takes a raw pointer.