### PR TITLE
[LLDB][GPU] Connect synchronously to the gpu process

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -951,9 +951,11 @@ Status ProcessGDBRemote::HandleConnectionRequest(const GPUActions &gpu_action) {
     return Status::FromErrorString("invalid platform for target needed for "
                                    "connecting to process");
 
-  ProcessSP process_sp = platform_sp->ConnectProcess(
+  // We wait for the process to fully stop before we can query or alter it via
+  // GPUActions.
+  ProcessSP process_sp = platform_sp->ConnectProcessSynchronous(
       connection_info.connect_url, GetPluginNameStatic(), debugger,
-      gpu_target_sp.get(), error);
+      *debugger.GetAsyncOutputStream(), gpu_target_sp.get(), error);
   if (error.Fail())
     return error;
   if (!process_sp)


### PR DESCRIPTION
As preliminary context, everything belows applies to the client. The server side is all fine.

For NVIDIA, after connecting to the GPU process we issue a resume_gpu GPUAction. We were doing that after connecting to the process asynchronously, which resulted in a race condition in which the following actions were happening at the same time:

- the gpu process was handling its stop state, fetching the state of its threads
- the GPUAction was issuing a Resume request

this caused that very often, after resuming, the gpu process was left in a Running state but with the thread metadata not cleared. Then, in the next stop event, it would reuse the previous thread metadata instead of using the new one.
Not only that, this sometimes caused many event listeners that were processing the original stop event to not complete their job after the GPUAction issued the Resume request.

A simple way to fix this is to connect to the gpu process synchronously. This ensures that all the stop event handlers have been processed and that we can safely issue the Resume without race conditions.

A better fix would be to add a WaitForProcessToStop right before processing GPUActions, but I wasn't able to make it work that way. I'm too ignorant.