### PR TITLE
[LLDB][GPU] Decouple plugins and scaffold documentation

### DIFF
--- a/lldb/docs/use/gpu-support.rst
+++ b/lldb/docs/use/gpu-support.rst
@@ -1,0 +1,15 @@
+GPU Support in LLDB
+====================
+
+AMD
+------
+
+System requirements
+^^^^^^^^^^^^^^^^^^^
+
+Mention how to set up ROMC.
+
+CMake
+^^^^^
+
+Mention something about the ROCM_PATH CMake variable and setting LLDB_ENABLE_AMDGPU_PLUGIN = ON.

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
@@ -18,13 +18,17 @@
 #include "lldb/Host/common/NativeProcessProtocol.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/lldb-private-forward.h"
-#include "LLDBServerPlugin.h"
 
 #include "GDBRemoteCommunicationServerCommon.h"
 
 class StringExtractorGDBRemote;
 
 namespace lldb_private {
+
+namespace lldb_server {
+  class LLDBServerPlugin;
+}
+
 namespace process_gdb_remote {
 
 class ProcessGDBRemote;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
@@ -18,17 +18,13 @@
 #include "lldb/Host/common/NativeProcessProtocol.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/lldb-private-forward.h"
+#include "LLDBServerPlugin.h"
 
 #include "GDBRemoteCommunicationServerCommon.h"
 
 class StringExtractorGDBRemote;
 
 namespace lldb_private {
-
-namespace lldb_server {
-  class LLDBServerPlugin;
-}
-
 namespace process_gdb_remote {
 
 class ProcessGDBRemote;

--- a/lldb/tools/lldb-server/CMakeLists.txt
+++ b/lldb/tools/lldb-server/CMakeLists.txt
@@ -45,22 +45,31 @@ endif()
 option(LLDB_ENABLE_AMDGPU_PLUGIN "Enable support for the AMD GPU plugin" OFF)
 option(LLDB_ENABLE_MOCK_GPU_PLUGIN "Enable support for the Mock GPU plugin" OFF)
 
+set(GPU_PLUGINS_ENABLED 0)
+
 if(LLDB_ENABLE_AMDGPU_PLUGIN)
   if(NOT DEFINED ROCM_PATH)
-    message(FATAL_ERROR "ROCM_PATH is not defined and LLDB_ENABLE_AMDGPU_PLUGIN expects it")
+    message(FATAL_ERROR "ROCM_PATH is not defined and LLDB_ENABLE_AMDGPU_PLUGIN expects it. Use -DROCM_PATH=/path/to/rocm")
   endif()
 
   if(NOT EXISTS ${ROCM_PATH})
-    message(FATAL_ERROR "ROCM_PATH does not exist: ${ROCM_PATH}")
+    message(FATAL_ERROR "ROCM_PATH does not exist: ${ROCM_PATH}. Use -DROCM_PATH=/path/to/rocm")
   endif()
+  message(STATUS "ROCM_PATH is set to: '${ROCM_PATH}'")
 
   add_definitions(-DLLDB_ENABLE_AMDGPU_PLUGIN=1)
   list(APPEND LLDB_PLUGINS lldbServerPluginAMDGPU)
+  math(EXPR GPU_PLUGINS_ENABLED "${GPU_PLUGINS_ENABLED} + 1")
 endif()
 
 if(LLDB_ENABLE_MOCK_GPU_PLUGIN)
   add_definitions(-DLLDB_ENABLE_MOCKGPU_PLUGIN=1)
   list(APPEND LLDB_PLUGINS lldbServerPluginMockGPU)
+  math(EXPR GPU_PLUGINS_ENABLED "${GPU_PLUGINS_ENABLED} + 1")
+endif()
+
+if(GPU_PLUGINS_ENABLED GREATER 1)
+  message(FATAL_ERROR "Only one GPU plugin can be enabled at a time")
 endif()
 
 add_lldb_tool(lldb-server

--- a/lldb/tools/lldb-server/CMakeLists.txt
+++ b/lldb/tools/lldb-server/CMakeLists.txt
@@ -42,10 +42,23 @@ if(APPLE_EMBEDDED)
   endif()
 endif()
 
-if(DEFINED ROCM_PATH)
+option(LLDB_ENABLE_AMDGPU_PLUGIN "Enable support for the AMD GPU plugin" OFF)
+option(LLDB_ENABLE_MOCK_GPU_PLUGIN "Enable support for the Mock GPU plugin" OFF)
+
+if(LLDB_ENABLE_AMDGPU_PLUGIN)
+  if(NOT DEFINED ROCM_PATH)
+    message(FATAL_ERROR "ROCM_PATH is not defined and LLDB_ENABLE_AMDGPU_PLUGIN expects it")
+  endif()
+
+  if(NOT EXISTS ${ROCM_PATH})
+    message(FATAL_ERROR "ROCM_PATH does not exist: ${ROCM_PATH}")
+  endif()
+
   add_definitions(-DLLDB_ENABLE_AMDGPU_PLUGIN=1)
   list(APPEND LLDB_PLUGINS lldbServerPluginAMDGPU)
-else()
+endif()
+
+if(LLDB_ENABLE_MOCK_GPU_PLUGIN)
   add_definitions(-DLLDB_ENABLE_MOCKGPU_PLUGIN=1)
   list(APPEND LLDB_PLUGINS lldbServerPluginMockGPU)
 endif()
@@ -71,7 +84,6 @@ add_lldb_tool(lldb-server
       lldbPluginInstructionMIPS64
       lldbPluginInstructionRISCV
       ${LLDB_SYSTEM_LIBS}
-      lldbServerPluginMockGPU
 )
 
 set_target_properties(lldb-server PROPERTIES ENABLE_EXPORTS 1)

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/CMakeLists.txt
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/CMakeLists.txt
@@ -1,13 +1,3 @@
-
-message(STATUS "ROCM_PATH is set to: '${ROCM_PATH}'")
-if(NOT ROCM_PATH)
-    message(FATAL_ERROR "ROCM_PATH must be specified. Use -DROCM_PATH=/path/to/rocm")
-endif()
-
-if (NOT EXISTS ${ROCM_PATH})
-    message(FATAL_ERROR "ROCM_PATH does not exist: '${ROCM_PATH}'")
-endif()
-
 # Find AMD-dbgapi package using the provided CMake config
 set(amd-dbgapi_DIR "${ROCM_PATH}/lib/cmake/amd-dbgapi" CACHE PATH "Path to amd-dbgapi cmake config")
 find_package(amd-dbgapi REQUIRED CONFIG)

--- a/lldb/tools/lldb-server/Plugins/CMakeLists.txt
+++ b/lldb/tools/lldb-server/Plugins/CMakeLists.txt
@@ -1,4 +1,7 @@
-if(DEFINED ROCM_PATH AND EXISTS ${ROCM_PATH})
+if(LLDB_ENABLE_AMDGPU_PLUGIN)
   add_subdirectory(AMDGPU)
 endif()
-add_subdirectory(MockGPU)
+
+if(LLDB_ENABLE_MOCK_GPU_PLUGIN)
+  add_subdirectory(MockGPU)
+endif()

--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -36,6 +36,7 @@
 #include "llvm/Support/Errno.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/WithColor.h"
+#include "Plugins/Process/gdb-remote/LLDBServerPlugin.h"
 
 #if defined(__linux__)
 #include "Plugins/Process/Linux/NativeProcessLinux.h"


### PR DESCRIPTION
- Add LLDB_ENABLE_[GPU plugin]_PLUGIN variables to programmatically enable each GPU plugin
- Make all the activation logic for all those plugins independent. This results in no `else` conditions, which makes rebases simpler.
- Theoretically, this would allow multiple plugins to be running at the same time. This sounds nice even though I don't think we'll ever work on it.
- Scaffold a tiny documentation file where we can put all the information related to the GPU plugins.