### PR TITLE
[LLDB][GPU] Add a GPUActions option for sync initialization

### DIFF
--- a/lldb/include/lldb/Utility/GPUGDBRemotePackets.h
+++ b/lldb/include/lldb/Utility/GPUGDBRemotePackets.h
@@ -122,6 +122,8 @@ struct GPUPluginConnectionInfo {
   std::optional<std::string> triple;
   /// The connection URL to use with "process connect <url>".
   std::string connect_url;
+  /// Synchronously wait for the GPU to initialize when connecting.
+  bool synchronous = false;
 };
 
 bool fromJSON(const llvm::json::Value &value, GPUPluginConnectionInfo &data,
@@ -190,10 +192,6 @@ struct GPUActions {
   /// Set this to true if the native plug-in sync with the GPU process and wait
   /// for it to return to a running state.
   bool wait_for_gpu_process_to_resume = false;
-  /// Set this to true if the native plug-in should wait synchronously for the
-  /// GPU process to initialize. This should be true if
-  /// `wait_for_gpu_process_to_resume` is set to true as part of initialization.
-  bool wait_synchronously_for_gpu_to_initialize = false;
 };
 
 bool fromJSON(const llvm::json::Value &value, GPUActions &data,

--- a/lldb/include/lldb/Utility/GPUGDBRemotePackets.h
+++ b/lldb/include/lldb/Utility/GPUGDBRemotePackets.h
@@ -190,6 +190,10 @@ struct GPUActions {
   /// Set this to true if the native plug-in sync with the GPU process and wait
   /// for it to return to a running state.
   bool wait_for_gpu_process_to_resume = false;
+  /// Set this to true if the native plug-in should wait synchronously for the
+  /// GPU process to initialize. This should be true if
+  /// `wait_for_gpu_process_to_resume` is set to true as part of initialization.
+  bool wait_synchronously_for_gpu_to_initialize = false;
 };
 
 bool fromJSON(const llvm::json::Value &value, GPUActions &data,

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -976,10 +976,8 @@ Status ProcessGDBRemote::HandleConnectionRequest(const GPUActions &gpu_action) {
     return Status::FromErrorString("invalid platform for target needed for "
                                    "connecting to process");
 
-  // We wait for the process to fully stop before we can query or alter it via
-  // GPUActions.
   ProcessSP process_sp =
-      gpu_action.wait_synchronously_for_gpu_to_initialize
+      gpu_action.connect_info->synchronous
           ? platform_sp->ConnectProcessSynchronous(
                 connection_info.connect_url, GetPluginNameStatic(), debugger,
                 *debugger.GetAsyncOutputStream(), gpu_target_sp.get(), error)

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -978,9 +978,14 @@ Status ProcessGDBRemote::HandleConnectionRequest(const GPUActions &gpu_action) {
 
   // We wait for the process to fully stop before we can query or alter it via
   // GPUActions.
-  ProcessSP process_sp = platform_sp->ConnectProcessSynchronous(
-      connection_info.connect_url, GetPluginNameStatic(), debugger,
-      *debugger.GetAsyncOutputStream(), gpu_target_sp.get(), error);
+  ProcessSP process_sp =
+      gpu_action.wait_synchronously_for_gpu_to_initialize
+          ? platform_sp->ConnectProcessSynchronous(
+                connection_info.connect_url, GetPluginNameStatic(), debugger,
+                *debugger.GetAsyncOutputStream(), gpu_target_sp.get(), error)
+          : platform_sp->ConnectProcess(connection_info.connect_url,
+                                        GetPluginNameStatic(), debugger,
+                                        gpu_target_sp.get(), error);
   if (error.Fail())
     return error;
   if (!process_sp)

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -386,7 +386,7 @@ std::optional<GPUActions> LLDBServerPluginAMDGPU::NativeProcessIsStopping() {
                        "launched successfully");
       }
       actions.connect_info = CreateConnection();
-      actions.connect_info.synchronous = true; 
+      actions.connect_info->synchronous = true; 
     }
     return actions;
   } else {

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -386,7 +386,7 @@ std::optional<GPUActions> LLDBServerPluginAMDGPU::NativeProcessIsStopping() {
                        "launched successfully");
       }
       actions.connect_info = CreateConnection();
-      actions.wait_synchronously_for_gpu_to_initialize = true;
+      actions.connect_info.synchronous = true; 
     }
     return actions;
   } else {

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -386,6 +386,7 @@ std::optional<GPUActions> LLDBServerPluginAMDGPU::NativeProcessIsStopping() {
                        "launched successfully");
       }
       actions.connect_info = CreateConnection();
+      actions.wait_synchronously_for_gpu_to_initialize = true;
     }
     return actions;
   } else {


### PR DESCRIPTION
I'm experimenting with initializating asynchronously and I think it's a good idea to make sync initialization an option in the GPU Actions. Given that AMD was using this by default, I modified it accordingly.