### PR TITLE
Allow halting native process with a fake stop reason

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -827,8 +827,13 @@ StreamString GDBRemoteCommunicationServerLLGS::PrepareStopReplyPacketForThread(
   StreamString response;
   struct ThreadStopInfo tid_stop_info;
   std::string description;
-  if (!thread.GetStopReason(tid_stop_info, description))
-    return response;
+  if (m_fake_stop_reason.has_value()) {
+    tid_stop_info = *m_fake_stop_reason;
+    m_fake_stop_reason = std::nullopt;
+  } else {
+    if (!thread.GetStopReason(tid_stop_info, description))
+      return response;
+  }
 
   // FIXME implement register handling for exec'd inferiors.
   // if (tid_stop_info.reason == eStopReasonExec) {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
@@ -112,6 +112,8 @@ public:
     return m_current_process;
   }
 
+  std::optional<ThreadStopInfo> m_fake_stop_reason;
+
 protected:
   MainLoop &m_mainloop;
   MainLoop::ReadHandleUP m_network_handle_up;

--- a/lldb/source/Plugins/Process/gdb-remote/LLDBServerPlugin.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/LLDBServerPlugin.cpp
@@ -21,15 +21,17 @@ LLDBServerPlugin::LLDBServerPlugin(GDBServer &native_process, MainLoop &main_loo
 LLDBServerPlugin::~LLDBServerPlugin() {}
 
 
-lldb::StateType 
-LLDBServerPlugin::HaltNativeProcessIfNeeded(bool &was_halted, 
-                                            uint32_t timeout_sec) {
+lldb::StateType
+LLDBServerPlugin::HaltNativeProcessIfNeeded(bool &was_halted,
+                                            uint32_t timeout_sec,
+                                            std::optional<ThreadStopInfo> stop_info) {
   using namespace std::chrono;
   NativeProcessProtocol *process = m_native_process.GetCurrentProcess();
   if (process->IsRunning()) {
     was_halted = true;
     process->Halt();
- 
+    m_native_process.m_fake_stop_reason = stop_info;
+
     auto end_time = steady_clock::now() + seconds(timeout_sec);
     while (std::chrono::steady_clock::now() < end_time) {
       std::this_thread::sleep_for(milliseconds(250));

--- a/lldb/source/Plugins/Process/gdb-remote/LLDBServerPlugin.h
+++ b/lldb/source/Plugins/Process/gdb-remote/LLDBServerPlugin.h
@@ -67,7 +67,8 @@ public:
   /// \return The actual state of the process in case the process was not able
   /// to be stopped within the specified timeout.
   lldb::StateType HaltNativeProcessIfNeeded(bool &was_halted,
-                                            uint32_t timeout_sec = 5);
+                                            uint32_t timeout_sec = 5,
+                                            std::optional<ThreadStopInfo> stop_reason = std::nullopt);
 
   /// Get notified when the process is stopping.
   ///

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -60,7 +60,10 @@ static amd_dbgapi_status_t amd_dbgapi_insert_breakpoint_callback(
             "insert_breakpoint callback at address: 0x%" PRIx64, address);
   LLDBServerPluginAMDGPU *debugger =
       reinterpret_cast<LLDBServerPluginAMDGPU *>(client_process_id);
-  debugger->GetNativeProcess()->Halt();
+  bool was_halted = false;
+  ThreadStopInfo stop_info;
+  stop_info.reason = eStopReasonDynamicLoader;
+  debugger->HaltNativeProcessIfNeeded(was_halted, 5, stop_info);
   LLDB_LOGF(GetLog(GDBRLog::Plugin), "insert_breakpoint callback success");
   LLDBServerPluginAMDGPU::GPUInternalBreakpoinInfo bp_info;
   bp_info.addr = address;


### PR DESCRIPTION
Example idea of how we can stop the cpu process with a fake stop reason so it can be auto-resumed. 

This is useful because we want to stop the CPU process to set a breakpoint at the address we get from the roc dbgapi. Stopping the cpu process at the point we get the callback ensures that set the breakpoint before the CPU process tries to load any new kernel code objects.

We need a fake stop reason so that the stop is not actually show to the user. It should be handled automatically by the debugger.

An alternative approach is in #18. There we stop the GPU process with a fake stop reason and use the GPUActions to set the breakpoint. The worry with that implementation is that the CPU process will not be stopped immediately and so we could miss hitting the breakpoint it asks us to set.