### PR TITLE
[amd] Set gpu loader breakpoint by name

### DIFF
--- a/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
@@ -69,13 +69,16 @@ class BasicAmdGpuTestCase(TestBase):
         self.runCmd("c")
         lldbutil.expect_state_changes(self, listener, cpu_process, [lldb.eStateRunning])
 
-        # TODO: Looks like the CPU is hitting an extra SIGSTOP for some reason so continue again after it stops.
-        lldbutil.expect_state_changes(self, listener, cpu_process, [lldb.eStateStopped])
-        self.dbg.SetSelectedTarget(cpu_target)
-        self.runCmd("c")
-        lldbutil.expect_state_changes(self, listener, cpu_process, [lldb.eStateRunning])
-
         # GPU breakpoint should get hit.
         lldbutil.expect_state_changes(self, listener, gpu_process, [lldb.eStateStopped])
         threads = lldbutil.get_threads_stopped_at_breakpoint_id(gpu_process, gpu_bkpt)
         self.assertNotEqual(None, threads, "GPU thread should be stopped at breakpoint")
+
+    def test_no_unexpected_stop(self):
+        """Test that we do not unexpectedly hit a stop in the debugger when
+        No breakpoints are set."""
+        self.build()
+
+        target = self.createTestTarget()
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertState(process.GetState(), lldb.eStateExited, PROCESS_EXITED)


### PR DESCRIPTION
Currently we set the gpu loader breakpoint by address in the `amd_dbgapi_insert_breakpoint_callback` callback. This means we need to halt the CPU in order to correctly set the breakpoint. When we halt the CPU it shows up as a public stop to the user and interrupts the debugging flow.

This PR changes it so that we set the loader breakpoint by name when we first create the gpu connection. We set the breakpoint on the `rocr::_loader_debug_state` function which was discovered by looking up the address passed into the callback.

This is a bit of a hack since the function name could potentially change over time or may be unavailable if the runtime was statically linked. But we use it for now to make the debugger experience better until we can find a more permanant solution.