### PR TITLE
[NFC] Create a base class for all GPU tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/gpu/amdgpu_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/gpu/amdgpu_testcase.py
@@ -1,39 +1,14 @@
-from lldbsuite.test.lldbtest import *
-import os
-import json
-from collections import namedtuple
+from lldbsuite.test.tools.gpu.gpu_testcase import GpuTestCaseBase
 import lldb
+from lldbsuite.test import lldbutil
+from lldbsuite.test.lldbtest import line_number
 
 
-#
-# Class that should be used by all python AMDGPU tests.
-#
-class AmdGpuTestCaseBase(TestBase):
+class AmdGpuTestCaseBase(GpuTestCaseBase):
+    """
+    Class that should be used by all python AMDGPU tests.
+    """
     NO_DEBUG_INFO_TESTCASE = True
-
-    def get_cpu_target(self):
-        """Return the CPU target. Assumes the CPU target is the first target."""
-        return self.dbg.GetTargetAtIndex(0)
-
-    def get_gpu_target(self):
-        """Return the GPU target. Assumes the GPU target is the second target."""
-        return self.dbg.GetTargetAtIndex(1)
-
-    def get_cpu_process(self):
-        """Return the GPU target. Assumes the GPU target is the second target."""
-        return self.get_cpu_target().GetProcess()
-
-    def get_gpu_process(self):
-        """Return the GPU target. Assumes the GPU target is the second target."""
-        return self.get_gpu_target().GetProcess()
-
-    def select_cpu(self):
-        """Select the CPU target."""
-        self.dbg.SetSelectedTarget(self.get_cpu_target())
-
-    def select_gpu(self):
-        """Select the GPU target."""
-        self.dbg.SetSelectedTarget(self.get_gpu_target())
 
     def run_to_gpu_breakpoint(
         self, source, gpu_bkpt_pattern, cpu_bkpt_pattern
@@ -47,7 +22,7 @@ class AmdGpuTestCaseBase(TestBase):
         (cpu_target, cpu_process, cpu_thread, cpu_bkpt) = (
             lldbutil.run_to_source_breakpoint(self, cpu_bkpt_pattern, source_spec)
         )
-        self.assertEqual(cpu_target, self.get_cpu_target())
+        self.assertEqual(cpu_target, self.cpu_target)
 
         # Switch to the GPU target so we can set a breakpoint.
         self.select_gpu()
@@ -65,15 +40,14 @@ class AmdGpuTestCaseBase(TestBase):
         listener = self.dbg.GetListener()
 
         # Continue the GPU process.
-        gpu_process = self.get_gpu_process()
         self.runCmd("c")
-        lldbutil.expect_state_changes(self, listener, gpu_process, [lldb.eStateRunning])
+        lldbutil.expect_state_changes(self, listener, self.gpu_process, [lldb.eStateRunning])
 
         # Continue the CPU process.
         self.select_cpu()
         self.runCmd("c")
-        lldbutil.expect_state_changes(self, listener, cpu_process, [lldb.eStateRunning])
+        lldbutil.expect_state_changes(self, listener, self.cpu_process, [lldb.eStateRunning])
 
         # GPU breakpoint should get hit.
-        lldbutil.expect_state_changes(self, listener, gpu_process, [lldb.eStateStopped])
-        return lldbutil.get_threads_stopped_at_breakpoint_id(gpu_process, gpu_bkpt)
+        lldbutil.expect_state_changes(self, listener, self.gpu_process, [lldb.eStateStopped])
+        return lldbutil.get_threads_stopped_at_breakpoint_id(self.gpu_process, gpu_bkpt)

--- a/lldb/packages/Python/lldbsuite/test/tools/gpu/gpu_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/gpu/gpu_testcase.py
@@ -1,0 +1,37 @@
+from lldbsuite.test.lldbtest import TestBase
+import lldb
+
+
+class GpuTestCaseBase(TestBase):
+    """
+    Class that should be used by all GPU tests.
+    """
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @property
+    def cpu_target(self):
+        """Return the CPU target. Assumes the CPU target is the first target."""
+        return self.dbg.GetTargetAtIndex(0)
+
+    @property
+    def gpu_target(self):
+        """Return the GPU target. Assumes the GPU target is the second target."""
+        return self.dbg.GetTargetAtIndex(1)
+
+    @property
+    def cpu_process(self):
+        """Return the GPU target. Assumes the GPU target is the second target."""
+        return self.cpu_target.GetProcess()
+
+    @property
+    def gpu_process(self):
+        """Return the GPU target. Assumes the GPU target is the second target."""
+        return self.gpu_target.GetProcess()
+
+    def select_cpu(self):
+        """Select the CPU target."""
+        self.dbg.SetSelectedTarget(self.cpu_target)
+
+    def select_gpu(self):
+        """Select the GPU target."""
+        self.dbg.SetSelectedTarget(self.gpu_target)

--- a/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
@@ -22,11 +22,11 @@ class BasicAmdGpuTestCase(AmdGpuTestCaseBase):
         (cpu_target, cpu_process, cpu_thread, cpu_bkpt) = lldbutil.run_to_source_breakpoint(
             self, "// CPU BREAKPOINT - BEFORE LAUNCH", source_spec
         )
-        self.assertEqual(self.get_cpu_target(), cpu_target)
+        self.assertEqual(self.cpu_target, cpu_target)
 
         # Make sure the GPU target was created and has the default thread.
         self.assertEqual(self.dbg.GetNumTargets(), 2, "There are two targets")
-        gpu_thread = self.get_gpu_process().GetThreadAtIndex(0)
+        gpu_thread = self.gpu_process.GetThreadAtIndex(0)
         self.assertEqual(gpu_thread.GetName(), "AMD Native Shadow Thread", "GPU thread has the right name")
 
     def test_gpu_breakpoint_hit(self):


### PR DESCRIPTION
This generalizes https://github.com/clayborg/llvm-project/pull/22 by creating a base test class for all GPU tests.

I changed some getters to properties to match the patterns already used by LLDB tests.