### PR TITLE
Integrate dual connection w/ LLDB-DAP using shared event thread

### DIFF
--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -44,6 +44,7 @@ public:
     eBroadcastBitWatchpointChanged = (1 << 3),
     eBroadcastBitSymbolsLoaded = (1 << 4),
     eBroadcastBitSymbolsChanged = (1 << 5),
+    eBroadcastBitNewTargetSpawned = (1 << 6),
   };
 
   // Constructors

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -536,6 +536,7 @@ public:
     eBroadcastBitWatchpointChanged = (1 << 3),
     eBroadcastBitSymbolsLoaded = (1 << 4),
     eBroadcastBitSymbolsChanged = (1 << 5),
+    eBroadcastBitNewTargetSpawned = (1 << 6),
   };
 
   // These two functions fill out the Broadcaster interface:

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -993,6 +993,10 @@ Status ProcessGDBRemote::HandleConnectionRequest(const GPUActions &gpu_action) {
                                  process_sp->GetTarget().shared_from_this());
   LLDB_LOG(log, "ProcessGDBRemote::HandleConnectionRequest(): successfully "
                 "created process!!!");
+  auto event_sp = std::make_shared<Event>(
+      Target::eBroadcastBitNewTargetSpawned,
+      new Target::TargetEventData(gpu_target_sp));
+  GetTarget().BroadcastEvent(event_sp);
   return Status();
 }
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -189,6 +189,7 @@ Target::Target(Debugger &debugger, const ArchSpec &target_arch,
   SetEventName(eBroadcastBitModulesUnloaded, "modules-unloaded");
   SetEventName(eBroadcastBitWatchpointChanged, "watchpoint-changed");
   SetEventName(eBroadcastBitSymbolsLoaded, "symbols-loaded");
+  SetEventName(eBroadcastBitNewTargetSpawned, "new-target-spawned");
 
   CheckInWithManager();
 

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -64,11 +64,12 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
   dap.ConfigureSourceMaps();
 
   lldb::SBError error;
-  lldb::SBTarget target = dap.CreateTarget(error);
-  if (error.Fail())
-    return ToError(error);
-
-  dap.SetTarget(target);
+  if (!dap.debugger.GetSelectedTarget().IsValid()) {
+    lldb::SBTarget target = dap.CreateTarget(error);
+    if (error.Fail())
+      return ToError(error);
+    dap.SetTarget(target);
+  }
 
   // Run any pre run LLDB commands the user specified in the launch.json
   if (Error err = dap.RunPreRunCommands())

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -282,13 +282,8 @@ serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
     g_loop.AddPendingCallback(
         [](MainLoopBase &loop) { loop.RequestTermination(); });
   });
-  std::condition_variable dap_sessions_condition;
-  std::mutex dap_sessions_mutex;
-  std::map<IOObject *, DAP *> dap_sessions;
   unsigned int clientCount = 0;
-  auto handle = listener->Accept(g_loop, [=, &dap_sessions_condition,
-                                          &dap_sessions_mutex, &dap_sessions,
-                                          &clientCount](
+  auto handle = listener->Accept(g_loop, [=, &clientCount](
                                              std::unique_ptr<Socket> sock) {
     std::string client_name = llvm::formatv("client_{0}", clientCount++).str();
     DAP_LOG(log, "({0}) client connected", client_name);
@@ -297,8 +292,7 @@ serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
 
     // Move the client into a background thread to unblock accepting the next
     // client.
-    std::thread client([=, &dap_sessions_condition, &dap_sessions_mutex,
-                        &dap_sessions]() {
+    std::thread client([=]() {
       llvm::set_thread_name(client_name + ".runloop");
       Transport transport(client_name, log, io, io);
       DAP dap(log, default_repl_mode, pre_init_commands, transport);
@@ -309,10 +303,8 @@ serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
         return;
       }
 
-      {
-        std::scoped_lock<std::mutex> lock(dap_sessions_mutex);
-        dap_sessions[io.get()] = &dap;
-      }
+      // Register the DAP session with the global manager
+      DAPSessionManager::GetInstance().RegisterSession(io, &dap);
 
       if (auto Err = dap.Loop()) {
         llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
@@ -321,9 +313,8 @@ serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
       }
 
       DAP_LOG(log, "({0}) client disconnected", client_name);
-      std::unique_lock<std::mutex> lock(dap_sessions_mutex);
-      dap_sessions.erase(io.get());
-      std::notify_all_at_thread_exit(dap_sessions_condition, std::move(lock));
+      // Unregister the DAP session from the global manager
+      DAPSessionManager::GetInstance().UnregisterSession(io);
     });
     client.detach();
   });
@@ -341,26 +332,11 @@ serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
       log,
       "lldb-dap server shutdown requested, disconnecting remaining clients...");
 
-  bool client_failed = false;
-  {
-    std::scoped_lock<std::mutex> lock(dap_sessions_mutex);
-    for (auto [sock, dap] : dap_sessions) {
-      if (llvm::Error error = dap->Disconnect()) {
-        client_failed = true;
-        llvm::errs() << "DAP client " << dap->transport.GetClientName()
-                     << " disconnected failed: "
-                     << llvm::toString(std::move(error)) << "\n";
-      }
-    }
-  }
+  // Disconnect all active sessions using the global manager
+  DAPSessionManager::GetInstance().DisconnectAllSessions();
 
   // Wait for all clients to finish disconnecting.
-  std::unique_lock<std::mutex> lock(dap_sessions_mutex);
-  dap_sessions_condition.wait(lock, [&] { return dap_sessions.empty(); });
-
-  if (client_failed)
-    return llvm::make_error<llvm::StringError>(
-        "disconnecting all clients failed", llvm::inconvertibleErrorCode());
+  DAPSessionManager::GetInstance().WaitForAllSessionsToDisconnect();
 
   return llvm::Error::success();
 }
@@ -560,6 +536,10 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
+  // Register the DAP session with the global manager for stdio mode
+  // This is needed for the event handling to find the correct DAP instance
+  DAPSessionManager::GetInstance().RegisterSession(input, &dap);
+
   // used only by TestVSCode_redirection_to_console.py
   if (getenv("LLDB_DAP_TEST_STDOUT_STDERR_REDIRECTION") != nullptr)
     redirection_test();
@@ -569,7 +549,9 @@ int main(int argc, char *argv[]) {
             llvm::toStringWithoutConsuming(Err));
     llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
                                 "DAP session error: ");
+    DAPSessionManager::GetInstance().UnregisterSession(input);
     return EXIT_FAILURE;
   }
+  DAPSessionManager::GetInstance().UnregisterSession(input);
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary
This PR adds support for dual connection debugging with LLDB-DAP using a shared debugger and event thread between DAP instances.
- Adds a new `Target` event `eBroadcastBitNewTargetSpawned`. This is sent from `ProcessGDBRemote` when it creates and connects a new GPU target. In `DAP::EventThread`, we create a reverse `startDebugging` request, and send it an attach configuration with `attachCommands` to `target select {x}` where x is the GPU target ID, to set the GPU DAP instance's target correctly.
- Adds a shared event thread field to DAP `std::shared_ptr<std::thread> event_thread_sp`;
- Refactors `lldb-dap.cpp` to use a static `DapSessionManager`. This holds and manages the lifetimes of the shared debugger and active DAP instances, rather than creating and storing local instances in `lldb-dap.cpp`. Instead of creating a new EventThread per DAP instance, we set the `event_thread_sp` to the shared pointer to a single running EventThread.
  - This holds an optional pointer `std::optional<lldb::SBDebugger> shared_debugger_` to a shared debugger. When a target is spawned for the GPU case, we will set this shared debugger, and set the debugger to the shared debugger instance in the `AttachRequestHandler`. Otherwise, the shared debugger is not set, so we maintain backwards compatibility.
  - This also holds `std::map<lldb::user_id_t, std::shared_ptr<std::thread>> debugger_event_threads_`. This maps debugger IDs to their shared event threads. If two DAP instances share a debugger, this allows us to return the correct shared event thread in `GetEventThreadForDebugger`. BC is still maintained, since if there's no shared debugger, we will create a new event thread like before.
- Inside the EventThread(), we get the active DAP sessions from the DapSessionManager and coordinate event handling using to the correct DAP session based on the Target associated with the event with `DAPSessionManager::FindDAPForTarget`.
- Once the reverse request is sent, VSCode creates a new debug child session under our main session, and LLDB-DAP creates a new DAP instance which passes through a `InitializeRequestHandler` and `AttachRequestHandler`. Rather than creating a new debugger in `InitializeRequestHandler`, we use the global shared debugger, and rather than creating a new target during the AttachRequestHandler, we already have the GPU target, so we just use these instances instead, and set the attributes of the DAP instance accordingly.
- After this, the shared event thread should take care of forwarding events to the correct DAP instances, and we should be able to debug on VSCode by toggling between the native and gpu processes. Breakpoints are shared and automatically handled by VSCode.

## Testing

Cherry-picked the changes on top of upstream LLVM, and DAP unit tests still pass.

Writing a new unit test will require some additional work, which can be followed up on subsequent changes, since existing python unit tests assume a single DAP session and don't know of the newly launched target. 

Did some manual testing on VSCode. We can hit breakpoints, continue, switch between the target sessions and send commands correctly.
<img width="872" height="726" alt="Screenshot 2025-08-06 at 2 38 37 PM" src="https://github.com/user-attachments/assets/6b2dcae4-a5f6-4607-8c01-1325f62ad048" />





