### PR TITLE
Create basic Mock GPU Plugin tests

### DIFF
--- a/lldb/test/API/gpu/mock/basic/Makefile
+++ b/lldb/test/API/gpu/mock/basic/Makefile
@@ -1,0 +1,2 @@
+CXX_SOURCES := hello_world.cpp
+include Makefile.rules

--- a/lldb/test/API/gpu/mock/basic/TestBasicMockGpuPlugin.py
+++ b/lldb/test/API/gpu/mock/basic/TestBasicMockGpuPlugin.py
@@ -1,0 +1,118 @@
+"""
+Basic tests for the Mock GPU Plugin.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.tools.gpu.gpu_testcase import GpuTestCaseBase
+
+CPU_BEFORE_BREAKPOINT_COMMENT = "// CPU BREAKPOINT - BEFORE INITIALIZE"
+CPU_AFTER_BREAKPOINT_COMMENT = "// CPU BREAKPOINT - AFTER INITIALIZE"
+GPU_BREAKPOINT_COMMENT = "// MOCK GPU BREAKPOINT"
+SOURCE_FILE = "hello_world.cpp"
+
+
+class BasicMockGpuTestCase(GpuTestCaseBase):
+    def setUp(self):
+        """Build the test program and run to the CPU breakpoint."""
+        super().setUp()
+        self.build()
+        self.source_spec = lldb.SBFileSpec(SOURCE_FILE, False)
+        (cpu_target, cpu_process, cpu_thread, cpu_bkpt) = (
+            lldbutil.run_to_source_breakpoint(
+                self, CPU_BEFORE_BREAKPOINT_COMMENT, self.source_spec
+            )
+        )
+
+    def test_mock_gpu_two_targets(self):
+        """
+        Verify that two targets exist: one CPU and one mock GPU.
+        Ensures the GPU thread is correctly named.
+        """
+        # Check that there is one CPU target before GPU is initialized.
+        self.assertEqual(self.dbg.GetNumTargets(), 1, "There is one CPU target")
+
+        # Continue to the breakpoint after GPU is initialized.
+        lldbutil.continue_to_source_breakpoint(
+            self, self.cpu_process, CPU_AFTER_BREAKPOINT_COMMENT, self.source_spec
+        )
+
+        # Check that there are two targets.
+        self.assertEqual(self.dbg.GetNumTargets(), 2, "There are two targets")
+
+        # Check the CPU target.
+        self.assertIsNotNone(self.cpu_target, "CPU target should exist")
+        self.assertTrue(self.cpu_target.GetProcess().IsValid(), "CPU process is valid")
+
+        # Check the GPU target.
+        self.assertIsNotNone(self.gpu_target, "GPU target should exist")
+        self.assertTrue(self.gpu_process.IsValid(), "GPU process is valid")
+        gpu_thread = self.gpu_process.GetThreadAtIndex(0)
+        self.assertEqual(
+            gpu_thread.GetName(),
+            "Mock GPU Thread Name",
+            "GPU thread has the right name",
+        )
+
+    def test_mock_gpu_register_read(self):
+        """
+        Test that we can read registers from the mock GPU target
+        and the "fake" register values are correct.
+        """
+        # Continue to the breakpoint after GPU is initialized.
+        lldbutil.continue_to_source_breakpoint(
+            self, self.cpu_process, CPU_AFTER_BREAKPOINT_COMMENT, self.source_spec
+        )
+
+        # Switch to the GPU target and read the registers.
+        self.select_gpu()
+        gpu_thread = self.gpu_process.GetThreadAtIndex(0)
+        gpu_frame = gpu_thread.GetFrameAtIndex(0)
+        gpu_registers_raw = lldbutil.get_registers(gpu_frame, "general purpose")
+
+        # Convert the registers to a dictionary for easier checking.
+        gpu_registers = {
+            reg.GetName(): reg.GetValueAsUnsigned() for reg in gpu_registers_raw
+        }
+
+        expected_registers = {
+            "R0": 0x0,
+            "R1": 0x1,
+            "R2": 0x2,
+            "R3": 0x3,
+            "R4": 0x4,
+            "R5": 0x5,
+            "R6": 0x6,
+            "R7": 0x7,
+            "SP": 0x8,
+            "FP": 0x9,
+            "PC": 0xA,
+            "Flags": 0xB,
+        }
+        for reg_name, expected_value in expected_registers.items():
+            self.assertIn(reg_name, gpu_registers)
+            self.assertEqual(
+                gpu_registers[reg_name],
+                expected_value,
+                f"Register {reg_name} value mismatch",
+            )
+
+    def test_mock_gpu_breakpoint_hit(self):
+        """Test that we can hit a breakpoint on the gpu target."""
+        # Switch to the GPU target and set a breakpoint.
+        self.select_gpu()
+        (gpu_target, gpu_process, gpu_thread, gpu_bkpt) = (
+            lldbutil.run_to_source_breakpoint(
+                self,
+                GPU_BREAKPOINT_COMMENT,
+                self.source_spec,
+            )
+        )
+
+        # Check the breakpoint was hit.
+        self.assertEqual(
+            gpu_bkpt.GetHitCount(),
+            1,
+            "Breakpoint should have been hit once",
+        )

--- a/lldb/test/API/gpu/mock/basic/hello_world.cpp
+++ b/lldb/test/API/gpu/mock/basic/hello_world.cpp
@@ -1,0 +1,27 @@
+#include <stdio.h>
+
+struct ShlibInfo {
+  const char *path;
+  ShlibInfo *next;
+};
+
+ShlibInfo g_shlib_list = {"/tmp/a.out", nullptr};
+
+int gpu_initialize() { return puts(__FUNCTION__); }
+int gpu_shlib_load() { return puts(__FUNCTION__); }
+int gpu_third_stop() { return puts(__FUNCTION__); }
+int gpu_kernel() {
+  // MOCK GPU BREAKPOINT
+  return puts(__FUNCTION__);
+}
+
+int main(int argc, const char **argv) {
+  // CPU BREAKPOINT - BEFORE INITIALIZE
+  gpu_initialize();
+  // CPU BREAKPOINT - AFTER INITIALIZE
+  gpu_shlib_load();
+  gpu_third_stop();
+  gpu_shlib_load();
+  gpu_kernel();
+  return 0;
+}


### PR DESCRIPTION
We add some unit tests for the Mock GPU Plugin, which checks 1) there are two targets (one for the native process and one for the mock gpu process), 2) we should have a thread called "Mock GPU Thread Name," 3) the registers on the mock GPU target has their values match the expected "fake" register values, and 4) we should be able to set and hit the expected breakpoints.

### Testing
```
$ ./bin/llvm-lit /lldb/test/API/gpu/mock/basic/TestBasicMockGpuPlugin.py -v
-- Testing: 1 tests, 1 workers --
PASS: lldb-api :: gpu/mock/basic/TestBasicMockGpuPlugin.py (1 of 1)

Testing Time: 2.93s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```