### PR TITLE
Call notify on StateSync condition variable when resuming

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -6397,8 +6397,7 @@ void ProcessGDBRemote::SyncState::SetStateStopped(uint64_t stop_id) {
 
 void ProcessGDBRemote::SyncState::DidResume() {
   Log *log = GetLog(GDBRLog::Plugin);
-  std::lock_guard<std::mutex> guard(m_mutex);
-  m_state = lldb::eStateRunning;
+  SetStateImpl(m_stop_id, lldb::eStateRunning);
   LLDB_LOG(log, "pid = {}, SyncState::{}() m_stop_id = {}, m_state = {}", 
            m_process.GetID(), __FUNCTION__,  m_stop_id, 
            StateAsCString(m_state.value_or(lldb::eStateInvalid)));

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -63,7 +63,7 @@ public:
     std::optional<uint64_t> m_stop_id;
     std::optional<lldb::StateType> m_state;
 
-    void SetStateImpl(uint64_t stop_id,  lldb::StateType state) {
+    void SetStateImpl(std::optional<uint64_t> stop_id,  lldb::StateType state) {
       // Scope to ensure the lock is released prior to calling notify.
       {
         std::lock_guard<std::mutex> guard(m_mutex);


### PR DESCRIPTION
We are currently missing a call to notify threads waiting on the StateSync condition variable when resuming the process. This causes the native process to miss out on notifications that the gpu process has resumed when waiting for the gpu to process to hit its requested stop id when `wait_for_gpu_process_to_resume` is true in GPUActions.