### PR TITLE
[GPU] Add utils library for gpu plugins

### DIFF
--- a/lldb/tools/lldb-server/CMakeLists.txt
+++ b/lldb/tools/lldb-server/CMakeLists.txt
@@ -79,6 +79,7 @@ add_lldb_tool(lldb-server
       lldbInitialization
       lldbVersion
       ${LLDB_PLUGINS}
+      lldbServerPluginUtils
       lldbPluginInstructionARM
       lldbPluginInstructionLoongArch
       lldbPluginInstructionMIPS

--- a/lldb/tools/lldb-server/Plugins/CMakeLists.txt
+++ b/lldb/tools/lldb-server/Plugins/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(Utils)
+
 if(LLDB_ENABLE_AMDGPU_PLUGIN)
   add_subdirectory(AMDGPU)
 endif()

--- a/lldb/tools/lldb-server/Plugins/Utils/CMakeLists.txt
+++ b/lldb/tools/lldb-server/Plugins/Utils/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_lldb_library(lldbServerPluginUtils
+  Utils.cpp
+)
+
+target_include_directories(lldbServerPluginUtils PRIVATE "${LLDB_SOURCE_DIR}/source" "../..")

--- a/lldb/tools/lldb-server/Plugins/Utils/Utils.cpp
+++ b/lldb/tools/lldb-server/Plugins/Utils/Utils.cpp
@@ -1,0 +1,45 @@
+//===-- Utils.cpp ---------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Utils.h"
+
+using namespace lldb;
+
+namespace lldb_private::lldb_server {
+
+llvm::StringRef StateToString(lldb::StateType state) {
+  switch (state) {
+  case eStateStopped:
+    return "stopped";
+  case eStateRunning:
+    return "running";
+  case eStateInvalid:
+    return "invalid";
+  case eStateUnloaded:
+    return "unloaded";
+  case eStateConnected:
+    return "connected";
+  case eStateAttaching:
+    return "attaching";
+  case eStateLaunching:
+    return "launching";
+  case eStateStepping:
+    return "stepping";
+  case eStateCrashed:
+    return "crashed";
+  case eStateDetached:
+    return "detached";
+  case eStateExited:
+    return "exited";
+  case eStateSuspended:
+    return "suspended";
+  }
+  return "unknown";
+}
+
+} // namespace lldb_private::lldb_server

--- a/lldb/tools/lldb-server/Plugins/Utils/Utils.h
+++ b/lldb/tools/lldb-server/Plugins/Utils/Utils.h
@@ -1,0 +1,43 @@
+//===-- Utils.h -------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TOOLS_LLDB_SERVER_UTILS_H
+#define LLDB_TOOLS_LLDB_SERVER_UTILS_H
+
+#include "Plugins/Process/gdb-remote/ProcessGDBRemoteLog.h"
+#include "llvm/Support/Error.h"
+
+namespace lldb_private::lldb_server {
+
+/// Variant of `createStringError` that uses `formatv` to format the error
+/// message. This allows complex string interpolations.
+template <typename... Args>
+llvm::Error createStringErrorFmt(const char *format, Args &&...args) {
+  return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                 llvm::formatv(format, args...).str());
+}
+
+/// This is the preferred way to abort the lldb-server due to a programmer
+/// error. It logs the error message and then calls `llvm::report_fatal_error`
+/// which will cause the lldb-server to crash and print a backtrace. It's worth
+/// mentioning that the backtrace is only printed if lldb-server is started
+/// manually on a terminal.
+template <typename... Args>
+[[noreturn]] void logAndReportFatalError(const char *format, Args &&...args) {
+  Log *log = GetLog(process_gdb_remote::GDBRLog::Plugin);
+  std::string err_msg = llvm::formatv(format, args...).str();
+  LLDB_LOG(log, "{0}", err_msg);
+  llvm::report_fatal_error(llvm::createStringError(err_msg));
+}
+
+/// Get a user-friendly string representation of a state.
+llvm::StringRef StateToString(lldb::StateType state);
+
+} // namespace lldb_private::lldb_server
+
+#endif // LLDB_TOOLS_LLDB_SERVER_UTILS_H


### PR DESCRIPTION
Adding the Utils.h and Utils.cpp from here:
https://github.com/clayborg/llvm-project/tree/88383298c7dbea9b0d93120aadde058044e5d937/lldb/tools/lldb-server/Plugins/NVIDIAGPU

as a static library so that we can use it in all the plugins.