### PR TITLE
[GPU][AMD] Refactor initialization code and delay connection

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/gpu/amdgpu_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/gpu/amdgpu_testcase.py
@@ -25,6 +25,7 @@ class AmdGpuTestCaseBase(GpuTestCaseBase):
         self.assertEqual(cpu_target, self.cpu_target)
 
         # Switch to the GPU target so we can set a breakpoint.
+        self.assertTrue(self.gpu_target.IsValid())
         self.select_gpu()
 
         # Set a breakpoint in the GPU source.


### PR DESCRIPTION
This PR refactors the amdgpu plugin initialization logic to make it more flexible so that we can choose when to initialize the debug library separately from attaching the process and creating the connection.

The change mostly shuffles around and cleans up existing code, but we now also explicitly track the state of the amd debug library (e.g. initialized, attached, runtime-initialized) so that we can use that to guide decisions around when to generate the debug connection.

We also fixed the connection logic after the changes in f1343a4.  That commit modified the timing of the `NativeProcessIsStopping` callback such that the callback is now triggered on the first stop that occurs when the native process is launched. This caused a problem because the GPUActions returned with that first stop-reply packet are ignored. The gdb-remote client sends a secondary `$?` packet to get the stop reply packet again, but then we would try to call the `initRocm` again because `m_connected` was false.

To avoid these problems we now delay sending the connection until after the initial stop that occurs for the native process when it first launches. I also played with delaying the connection even further to when the rocm runtime is initialized. That works, but it makes it awkward to use the debugger to set gpu breakpoints. The runtime is initialized on demand so there is not always a good place to set a cpu breakpoint where we can halt the process and create the gpu breakpoints. If we change the debugger to propagate the breakpoints from the cpu to gpu then this will not be an issue because we can set the breakpoints before the gpu target is created.