### PR TITLE
Allow passing LD_EXTRAS environment variable down to dotest.py

### DIFF
--- a/lldb/test/API/lldbtest.py
+++ b/lldb/test/API/lldbtest.py
@@ -59,6 +59,9 @@ class LLDBTest(TestFormat):
             cmd.extend(["--env", "LUA_EXECUTABLE=%s" % test.config.lua_executable])
             cmd.extend(["--env", "LLDB_LUA_CPATH=%s" % test.config.lldb_lua_cpath])
 
+        if "DOTEST_LD_EXTRAS" in os.environ:
+            cmd.extend(["--env", "LD_EXTRAS=%s" % os.environ["DOTEST_LD_EXTRAS"]])
+
         timeoutInfo = None
         try:
             out, err, exitCode = lit.util.executeCommand(


### PR DESCRIPTION
This is to workaround a dynamic linker bug:
https://sourceware.org/bugzilla/show_bug.cgi?id=33224

We can run tests that use a working ld.so like this:

```
$ DOTEST_LD_EXTRAS=-Wl,--dynamic-linker=<path/to/working/ld.so> llvm-lit
```