### PR TITLE
[GPU][AMD] Increase the size of the max CIE augmentation string

### DIFF
--- a/lldb/include/lldb/Symbol/DWARFCallFrameInfo.h
+++ b/lldb/include/lldb/Symbol/DWARFCallFrameInfo.h
@@ -80,7 +80,7 @@ public:
       const std::function<bool(lldb::addr_t, uint32_t, dw_offset_t)> &callback);
 
 private:
-  enum { CFI_AUG_MAX_SIZE = 8, CFI_HEADER_SIZE = 8 };
+  enum { CFI_AUG_MAX_SIZE = 12, CFI_HEADER_SIZE = 8 };
   enum CFIVersion {
     CFI_VERSION1 = 1, // DWARF v.2
     CFI_VERSION3 = 3, // DWARF v.3
@@ -173,6 +173,7 @@ private:
   lldb::RegisterKind GetRegisterKind() const {
     return m_type == EH ? lldb::eRegisterKindEHFrame : lldb::eRegisterKindDWARF;
   }
+  friend class DWARFCallFrameInfoTest;
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
The CIE storage uses a fixed size buffer to parse the augmentation string. The AMDGPU backend uses an augmentation string that exceeds the current size, which causes the parser to fail. This PR increases the storage size to fit the AMDGPU augmentation string and adds a test to validate that we can parse it successfully.