### PR TITLE
[LLDB][NVIDIA] Enhance ABI and Process for Address Space Management

### DIFF
--- a/lldb/include/lldb/Target/ABI.h
+++ b/lldb/include/lldb/Target/ABI.h
@@ -19,6 +19,8 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/MC/MCRegisterInfo.h"
 
+#include <optional>
+
 namespace llvm {
 class Type;
 }
@@ -149,6 +151,18 @@ public:
   virtual bool GetPointerReturnRegister(const char *&name) { return false; }
 
   virtual uint64_t GetStackFrameSize() { return 512 * 1024; }
+
+  /// Get the default address space for saved registers. This allows
+  /// architectures to specify that saved registers should be read from
+  /// a specific address space.
+  ///
+  /// \return
+  ///     An optional numeric address space identifier. If no special
+  ///     address space is needed, returns std::nullopt.
+  virtual std::optional<uint64_t>
+  GetDefaultAddressSpaceForSavedRegisters() const {
+    return std::nullopt;
+  }
 
   static lldb::ABISP FindPlugin(lldb::ProcessSP process_sp, const ArchSpec &arch);
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -441,17 +441,33 @@ public:
   llvm::Expected<lldb::addr_t> ResolveAddressInDefaultAddressSpace(
       lldb_private::Process &process) const;
 
+  /// \return
+  ///     The address value, which can be a load address, file address, or
+  ///     offset depending on how this AddressSpec was constructed.
   uint64_t GetValue() const { return m_value; }
+
+  /// \return
+  ///     A StringRef to the address space name if it was specified via the
+  ///     string-based constructor, or an empty StringRef if no name is set.
   llvm::StringRef GetSpaceName() const { 
     if (m_addr_space_name.has_value()) 
       return *m_addr_space_name;
     return llvm::StringRef();
   }
+
+  /// \return
+  ///     An optional containing the address space ID if this AddressSpec was
+  ///     constructed with a numeric address space identifier, or std::nullopt
+  ///     if no numeric ID is set.
+  std::optional<uint64_t> GetSpaceId() const { return m_addr_space_id; }
+
   llvm::Expected<AddressSpaceInfo> GetAddressSpaceInfo(
       lldb_private::Process &process) const;
+
   // Return an error if this is module specific and the module has expired, 
   // otherwise return a ModuleSP, even if it is empty.
   llvm::Expected<lldb::ModuleSP> GetModule() const;
+
   // Return an error if this is thread specific and the thread has expired, 
   // otherwise return a ThreadSP, even if it is empty.
   llvm::Expected<lldb::ThreadSP> GetThread() const;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1941,10 +1941,7 @@ size_t Process::ReadMemory(const AddressSpec &addr_spec, void *buf,
   }
   // We have an address that can't be resolved in the default address space, so
   // we need to call the overload that knows how to read from an address space.
-  // Check if we have a numeric address space ID first.
-  llvm::Expected<AddressSpaceInfo> info =
-      addr_spec.GetSpaceId() ? GetAddressSpaceInfo(*addr_spec.GetSpaceId())
-                             : GetAddressSpaceInfo(addr_spec.GetSpaceName());
+  llvm::Expected<AddressSpaceInfo> info = addr_spec.GetAddressSpaceInfo(*this);
 
   if (info)
     return DoReadMemory(addr_spec, *info, buf, size, error);

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1941,8 +1941,11 @@ size_t Process::ReadMemory(const AddressSpec &addr_spec, void *buf,
   }
   // We have an address that can't be resolved in the default address space, so
   // we need to call the overload that knows how to read from an address space.
-  llvm::Expected<AddressSpaceInfo> info = 
-      GetAddressSpaceInfo(addr_spec.GetSpaceName());
+  // Check if we have a numeric address space ID first.
+  llvm::Expected<AddressSpaceInfo> info =
+      addr_spec.GetSpaceId() ? GetAddressSpaceInfo(*addr_spec.GetSpaceId())
+                             : GetAddressSpaceInfo(addr_spec.GetSpaceName());
+
   if (info)
     return DoReadMemory(addr_spec, *info, buf, size, error);
   error = Status::FromError(info.takeError());


### PR DESCRIPTION
- Added a method to ABI for retrieving the default address space for saved registers when unwinding, returning an optional integer address space identifier.
- Updated Process to allow a numeric address space ID when resolving addresses for memory reads.
- Enhanced RegisterContext to check for ABI-specified address spaces when reading register values from memory.