### PR TITLE
[lldb][GPU] Fix bug where we handle GPUActions multiple times

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -934,7 +934,7 @@ Status ProcessGDBRemote::HandleGPUActions(const GPUActions &gpu_action) {
   }
 
   // This is the CPU process.
-  uint32_t current_stop_id = GetStopId();
+  uint32_t current_stop_id = GetStopID();
   auto it = m_processed_gpu_actions.find(gpu_action.plugin_name);
   if (it != m_processed_gpu_actions.end() && it->second == current_stop_id) {
     LLDB_LOG(log,
@@ -942,12 +942,12 @@ Status ProcessGDBRemote::HandleGPUActions(const GPUActions &gpu_action) {
              "processed GPU actions for plugin '{0}' with process stop_id {1}",
              gpu_action.plugin_name, current_stop_id);
     return Status();
+  }
   m_processed_gpu_actions[gpu_action.plugin_name] = current_stop_id;
   LLDB_LOG(log,
            "ProcessGDBRemote::HandleGPUActions processing GPU actions "
            "for plugin '{0}' with process stop_id {1}",
            gpu_action.plugin_name, current_stop_id);
-  }
   Status error;
   if (!gpu_action.breakpoints.empty())
     HandleGPUBreakpoints(gpu_action);

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -554,6 +554,9 @@ private:
   llvm::StringMap<std::unique_ptr<FieldEnum>> m_registers_enum_types;
 
   SyncState m_sync_state;
+  
+  //  Map to track processed GPU actions.
+  std::map<std::string, uint32_t> m_processed_gpu_actions;
 };
 
 } // namespace process_gdb_remote

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -556,7 +556,7 @@ private:
   SyncState m_sync_state;
   
   //  Map to track processed GPU actions.
-  std::map<std::string, uint32_t> m_processed_gpu_actions;
+  std::unordered_map<std::string, uint32_t> m_processed_gpu_actions;
 };
 
 } // namespace process_gdb_remote

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -429,8 +429,7 @@ bool LLDBServerPluginAMDGPU::ReadyToSendConnectionRequest() {
   // The GPUActions are ignored on the initial stop when the process is first
   // launched so we wait until the second stop to send the connection request.
   const bool ready = m_amd_dbg_api_state == AmdDbgApiState::Attached &&
-                     !m_is_connected && !m_is_listening &&
-                     GetNativeProcess()->GetStopID() > 1;
+                     !m_is_connected && !m_is_listening;
 
   LLDB_LOGF(GetLog(GDBRLog::Plugin),
             "%s - ready: %d dbg_api_state: %d, connected: %d, listening: %d, "


### PR DESCRIPTION
There is a bug that happens when you connect to the server where target list shows:
```
(lldb) target list
Current targets:
  target #0: /data/users/peix/llvm/gpu/build/Debug/a.out ( arch=x86_64-unknown-linux-gnu, platform=host, pid=622763, state=stopped )
  target #1: <none> ( arch=amdgcn-amd-amdhsa--gfx942, platform=host, pid=1, state=stopped )
* target #2: <none> ( platform=host, state=unloaded )
```

The workflow: 
Process Launch -> initial stop (lldb always stops at launch) -> server gets notified -> 
server decide to send GPU actions in NativeProcessIsStopping() -> ready is returning true in ReadyToSendConnectionRequest -> 
Client is receiving the stop packet (our first process, GPU target created) ->  m_last_stop_packet = response (contains GPUactions) ->
LLDB calls RefreshStateAfterStop() (normal behavior) -> m_last_stop_packet is True so we reprocess the same packet -> 
SetThreadStopInfo(*m_last_stop_packet) -> Second Processing of Same GPU-Actions -> ParsePairs() extracts SAME: key="gpu-actions" ->
HandleGPUActions called for the second time -> HandleConnectionRequest() -> Tries to create SECOND GPU target. 

The two calls originate from this code:
https://github.com/clayborg/llvm-project/blob/llvm-server-plugins/lldb/source/Target/Process.cpp#L3276C1-L3291C6

The call on line 3267 to DoConnectRemote leads to a call to SetThreadStopInfo, which then calls HandleGPUActions.

Then the call on line 3289 to HandlePrivateEvent again leads to a call to SetTheadStopInfo (via RefreshStateAfterStop), which then calls HandleGPUActions for the same set of actions.

my fix is that the original stop packet (with GPU actions) is still cached in `m_last_stop_packet`, but we create a copy of the cached packet and strip the gpu-actions. 
