### PR TITLE
[GPU][AMD] Create unique_ptr to deallocate client memory

### DIFF
--- a/lldb/tools/lldb-server/Plugins/AMDGPU/AmdDbgApiHelpers.h
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/AmdDbgApiHelpers.h
@@ -15,6 +15,7 @@
 #define LLDB_TOOLS_LLDB_SERVER_AMDDBGAPIHELPERS_H
 #include <algorithm>
 #include <amd-dbgapi/amd-dbgapi.h>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -87,6 +88,21 @@ private:
   std::vector<amd_dbgapi_event_kind_t> m_events;
   amd_dbgapi_event_id_t m_last_event_id = AMD_DBGAPI_EVENT_NONE;
 };
+
+// Custom deleter for std::unique_ptr that uses FreeDbgApiClientMemory
+struct DbgApiClientMemoryDeleter {
+  void operator()(void *ptr) const;
+};
+
+// Type alias for std::unique_ptr with the custom deleter
+//
+// Example usage:
+// auto ptr =
+// DbgApiClientMemoryPtr<SomeType>(static_cast<SomeType*>(raw_ptr_from_dbgapi));
+// The memory will be automatically freed when ptr goes out of scope
+template <typename T>
+using DbgApiClientMemoryPtr = std::unique_ptr<T, DbgApiClientMemoryDeleter>;
+
 } // namespace lldb_server
 } // namespace lldb_private
 #endif

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -36,6 +36,12 @@ using namespace lldb_private;
 using namespace lldb_private::lldb_server;
 using namespace lldb_private::process_gdb_remote;
 
+void DbgApiClientMemoryDeleter::operator()(void *ptr) const {
+  if (ptr) {
+    LLDBServerPluginAMDGPU::FreeDbgApiClientMemory(ptr);
+  }
+}
+
 static amd_dbgapi_status_t amd_dbgapi_client_process_get_info_callback(
     amd_dbgapi_client_process_id_t client_process_id,
     amd_dbgapi_client_process_info_t query, size_t value_size, void *value) {

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -36,12 +36,6 @@ using namespace lldb_private;
 using namespace lldb_private::lldb_server;
 using namespace lldb_private::process_gdb_remote;
 
-void DbgApiClientMemoryDeleter::operator()(void *ptr) const {
-  if (ptr) {
-    LLDBServerPluginAMDGPU::FreeDbgApiClientMemory(ptr);
-  }
-}
-
 static amd_dbgapi_status_t amd_dbgapi_client_process_get_info_callback(
     amd_dbgapi_client_process_id_t client_process_id,
     amd_dbgapi_client_process_info_t query, size_t value_size, void *value) {

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.h
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.h
@@ -70,7 +70,7 @@ public:
   }
 
   // Free the memory using the matching callback provided to the debug library.
-  void FreeDbgApiClientMemory(void *mem);
+  static void FreeDbgApiClientMemory(void *mem);
 
   bool CreateGPUBreakpoint(uint64_t addr);
 

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.h
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.h
@@ -135,6 +135,13 @@ private:
   AmdDbgApiState m_amd_dbg_api_state = AmdDbgApiState::Uninitialized;
 };
 
+// Helper to free memory with custom deleter for unique_ptr.
+inline void DbgApiClientMemoryDeleter::operator()(void *ptr) const {
+  if (ptr) {
+    LLDBServerPluginAMDGPU::FreeDbgApiClientMemory(ptr);
+  }
+}
+
 } // namespace lldb_server
 } // namespace lldb_private
 

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.cpp
@@ -396,6 +396,8 @@ bool ProcessAMDGPU::handleDebugEvent(amd_dbgapi_event_id_t eventId,
       return result;
     }
 
+    DbgApiClientMemoryPtr<amd_dbgapi_code_object_id_t>
+        code_objects_list_deleter(code_object_list);
     m_gpu_module_manager.BeginCodeObjectListUpdate();
     for (size_t i = 0; i < count; ++i) {
       uint64_t l_addr;
@@ -413,12 +415,12 @@ bool ProcessAMDGPU::handleDebugEvent(amd_dbgapi_event_id_t eventId,
       if (status != AMD_DBGAPI_STATUS_SUCCESS)
         continue;
 
+      DbgApiClientMemoryPtr<char> uri_bytes_deleter(uri_bytes);
       LLDB_LOGF(GetLog(GDBRLog::Plugin),
                 "Code object %zu: %s at address %" PRIu64, i, uri_bytes,
                 l_addr);
 
       m_gpu_module_manager.CodeObjectIsLoaded(uri_bytes, l_addr);
-      m_debugger->FreeDbgApiClientMemory(uri_bytes);
     }
     m_gpu_module_manager.EndCodeObjectListUpdate();
     break;


### PR DESCRIPTION
Create a unique_ptr type that can be used to automatically free memory
allocated by the amddbg api. It calls back into the
LLDBServerPluginAMDGPU::FreeDbgApiClientMemory function to actually free
the memory.

Opportunistically use this new wrapper to fix a memory leak.