### PR TITLE
[LLDB][GPU] Add support for copying cpu breakpoints during connection

### DIFF
--- a/lldb/include/lldb/Utility/GPUGDBRemotePackets.h
+++ b/lldb/include/lldb/Utility/GPUGDBRemotePackets.h
@@ -126,6 +126,8 @@ struct GPUPluginConnectionInfo {
   std::string connect_url;
   /// Synchronously wait for the GPU to initialize when connecting.
   bool synchronous = false;
+  /// Whether to copy the CPU breakpoints to the GPU target during attaching.
+  bool copy_cpu_breakpoints_during_attaching = false;
 };
 
 bool fromJSON(const llvm::json::Value &value, GPUPluginConnectionInfo &data,

--- a/lldb/source/Utility/GPUGDBRemotePackets.cpp
+++ b/lldb/source/Utility/GPUGDBRemotePackets.cpp
@@ -92,7 +92,9 @@ bool fromJSON(const llvm::json::Value &value, GPUPluginConnectionInfo &data,
          o.mapOptional("platform_name", data.platform_name) &&
          o.mapOptional("triple", data.triple) &&
          o.map("connect_url", data.connect_url) &&
-         o.map("synchronous", data.synchronous);
+         o.map("synchronous", data.synchronous) &&
+         o.map("copy_cpu_breakpoints_during_attaching",
+               data.copy_cpu_breakpoints_during_attaching);
 }
 
 llvm::json::Value toJSON(const GPUPluginConnectionInfo &data) {
@@ -102,6 +104,8 @@ llvm::json::Value toJSON(const GPUPluginConnectionInfo &data) {
       {"triple", data.triple},
       {"connect_url", data.connect_url},
       {"synchronous", data.synchronous},
+      {"copy_cpu_breakpoints_during_attaching",
+       data.copy_cpu_breakpoints_during_attaching},
   });
 }
 

--- a/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
@@ -124,6 +124,7 @@ std::optional<GPUPluginConnectionInfo> LLDBServerPluginMockGPU::CreateConnection
     const uint16_t listen_port = (*sock)->GetLocalPortNumber();
     connection_info.connect_url = llvm::formatv("connect://localhost:{}", 
                                                 listen_port);
+    connection_info.copy_cpu_breakpoints_during_attaching = true;
     LLDB_LOGF(log, "%s listening to %u", __PRETTY_FUNCTION__, listen_port);
     
     m_listen_socket = std::move(*sock);


### PR DESCRIPTION
- Add an option to GPUPluginConnectionInfo that indicates LLDB to copy the cpu breakpoints to the gpu target during connection time.
- After connection, breakpoints can be set independently on each target.

If this gets greenlit, I'll write corresponding support to the mock gpu and add some tests.