### PR TITLE
[LLDB][GPU] Only enable mockgpu tests when needed

### DIFF
--- a/lldb/test/API/gpu/mock/lit.local.cfg
+++ b/lldb/test/API/gpu/mock/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "lldb-mock-gpu" in config.enabled_plugins:
+    config.unsupported = True

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -52,6 +52,10 @@ if lldb_build_intel_pt == '1':
     config.enabled_plugins.append('intel-pt')
 
 # GPU Plugins
+lldb_enable_mock_gpu_plugin = '@LLDB_ENABLE_MOCK_GPU_PLUGIN@'
+if lldb_enable_mock_gpu_plugin in ('ON', '1'):
+    config.enabled_plugins.append('lldb-mock-gpu')
+
 lldb_enable_amdgpu_plugin = '@LLDB_ENABLE_AMDGPU_PLUGIN@'
 if lldb_enable_amdgpu_plugin == 'ON' or lldb_enable_amdgpu_plugin == '1':
     config.enabled_plugins.append('lldb-amdgpu')


### PR DESCRIPTION
These tests were running even when the plugin was disabled.