### PR TITLE
[NVGPU] Add initial DAP support

### DIFF
--- a/lldb/include/lldb/Utility/GPUGDBRemotePackets.h
+++ b/lldb/include/lldb/Utility/GPUGDBRemotePackets.h
@@ -230,6 +230,8 @@ struct GPUActions {
 
   /// The name of the plugin.
   std::string plugin_name;
+  /// The name to give a DAP session.
+  std::string session_name;
   /// Unique identifier for every GPU action.
   uint32_t identifier = 0;
   /// The stop ID in the process that this action is associated with. If the

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -482,20 +482,27 @@ class DebugCommunication(object):
                 }
             )
         elif request["command"] == "startDebugging":
-            self.send_packet(
-                {
-                    "type": "response",
-                    "seq": 0,
-                    "request_seq": request["seq"],
-                    "success": True,
-                    "message": None,
-                    "command": "startDebugging",
-                    "body": {},
-                }
-            )
+            self._handle_startDebugging_request(request)
         else:
             desc = 'unknown reverse request "%s"' % (request["command"])
             raise ValueError(desc)
+
+    def _handle_startDebugging_request(self, request: Request) -> None:
+        """Handle startDebugging reverse request.
+
+        Base implementation that just sends a success response.
+        DebugAdapterServer overrides this to create child sessions.
+        """
+        self.send_packet(
+            {
+                "type": "response",
+                "seq": 0,
+                "request_seq": request["seq"],
+                "success": True,
+                "command": "startDebugging",
+                "body": {},
+            }
+        )
 
     def _process_continued(self, all_threads_continued: bool):
         self.frame_scopes = {}
@@ -1535,6 +1542,9 @@ class DebugAdapterServer(DebugCommunication):
     ):
         self.process = None
         self.connection = None
+        self.child_dap_sessions: Dict[int, "DebugAdapterServer"] = (
+            {}
+        )  # Track child sessions for GPU debugging
         if executable is not None:
             process, connection = DebugAdapterServer.launch(
                 executable=executable,
@@ -1573,6 +1583,10 @@ class DebugAdapterServer(DebugCommunication):
                 log_file,
                 spawn_helper,
             )
+
+    def get_child_sessions(self) -> Dict[int, "DebugAdapterServer"]:
+        """Return dictionary of child DAP sessions (for GPU debugging)."""
+        return self.child_dap_sessions
 
     @classmethod
     def launch(
@@ -1638,6 +1652,70 @@ class DebugAdapterServer(DebugCommunication):
         if self.process:
             return self.process.pid
         return -1
+
+    def _handle_startDebugging_request(self, request: Request) -> None:
+        """Handle startDebugging reverse request by creating child DAP sessions.
+
+        This override creates child DAP sessions for GPU debugging.
+        """
+        try:
+            arguments = request.get("arguments", {})
+            request_type = arguments.get("request", "attach")
+            configuration = arguments.get("configuration", {})
+            debugger_id = configuration.get("debuggerId")
+            target_id = configuration.get("targetId")
+
+            # Validate that both debugger_id and target_id are provided together
+            if (debugger_id is None) != (target_id is None):
+                raise ValueError(
+                    "Both debuggerId and targetId must be specified together for debugger "
+                    "reuse, or both must be omitted to create a new debugger"
+                )
+
+            # Create a new child DAP session using the same connection
+            child_dap = DebugAdapterServer(
+                connection=self.connection,
+                log_file=self.log_file,
+            )
+
+            # Configure the child session based on the request type
+            if request_type == "attach":
+                child_dap.request_initialize()
+
+                attach_commands = configuration.get("attachCommands", [])
+                self.child_dap_sessions[target_id] = child_dap
+
+                child_dap.request_attach(
+                    debuggerId=debugger_id,
+                    targetId=target_id,
+                    attachCommands=attach_commands,
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported startDebugging request type: {request_type}"
+                )
+
+            # Send success response
+            response = {
+                "type": "response",
+                "request_seq": request.get("seq", 0),
+                "success": True,
+                "command": "startDebugging",
+                "body": {},
+            }
+
+        except Exception as e:
+            # Send error response
+            response = {
+                "type": "response",
+                "request_seq": request.get("seq", 0),
+                "success": False,
+                "command": "startDebugging",
+                "message": f"Failed to start debugging: {str(e)}",
+                "body": {},
+            }
+
+        self.send_packet(response)
 
     def terminate(self):
         try:

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -84,11 +84,20 @@ class DAPTestCaseBase(TestBase):
     def set_source_breakpoints_from_source(
         self, source: Source, lines, data=None, wait_for_resolve=True
     ):
-        response = self.dap_server.request_setBreakpoints(
-            source,
-            lines,
-            data,
+        return self._set_source_breakpoints_impl(
+            self.dap_server, source, lines, data, wait_for_resolve
         )
+
+    def _set_source_breakpoints_impl(
+        self,
+        dap_server_instance,
+        source: Source,
+        lines,
+        data=None,
+        wait_for_resolve=True,
+    ):
+        """Implementation for setting source breakpoints on any DAP server"""
+        response = dap_server_instance.request_setBreakpoints(source, lines, data)
         if response is None:
             return []
         breakpoints = response["body"]["breakpoints"]
@@ -96,7 +105,7 @@ class DAPTestCaseBase(TestBase):
         for breakpoint in breakpoints:
             breakpoint_ids.append("%i" % (breakpoint["id"]))
         if wait_for_resolve:
-            self.wait_for_breakpoints_to_resolve(breakpoint_ids)
+            self.wait_for_breakpoints_to_resolve(breakpoint_ids, dap_server_instance)
         return breakpoint_ids
 
     def set_function_breakpoints(
@@ -119,9 +128,13 @@ class DAPTestCaseBase(TestBase):
             self.wait_for_breakpoints_to_resolve(breakpoint_ids)
         return breakpoint_ids
 
-    def wait_for_breakpoints_to_resolve(self, breakpoint_ids: list[str]):
-        unresolved_breakpoints = self.dap_server.wait_for_breakpoints_to_be_verified(
-            breakpoint_ids
+    def wait_for_breakpoints_to_resolve(
+        self, breakpoint_ids: list[str], dap_server_instance=None
+    ):
+        if dap_server_instance is None:
+            dap_server_instance = self.dap_server
+        unresolved_breakpoints = (
+            dap_server_instance.wait_for_breakpoints_to_be_verified(breakpoint_ids)
         )
         self.assertEqual(
             len(unresolved_breakpoints),
@@ -159,7 +172,12 @@ class DAPTestCaseBase(TestBase):
         "breakpoint_ids" should be a list of breakpoint ID strings
         (["1", "2"]). The return value from self.set_source_breakpoints()
         or self.set_function_breakpoints() can be passed to this function"""
-        stopped_events = self.dap_server.wait_for_stopped()
+        return self._verify_breakpoint_hit_impl(self.dap_server, breakpoint_ids)
+
+    def _verify_breakpoint_hit_impl(
+        self, dap_server_instance, breakpoint_ids: List[Union[int, str]]
+    ):
+        stopped_events = dap_server_instance.wait_for_stopped()
         normalized_bp_ids = [str(b) for b in breakpoint_ids]
         for stopped_event in stopped_events:
             if "body" in stopped_event:
@@ -420,7 +438,10 @@ class DAPTestCaseBase(TestBase):
         return None
 
     def do_continue(self):  # `continue` is a keyword.
-        resp = self.dap_server.request_continue()
+        return self._do_continue_impl(self.dap_server)
+
+    def _do_continue_impl(self, dap_server_instance):
+        resp = dap_server_instance.request_continue()
         self.assertTrue(resp["success"], f"continue request failed: {resp}")
 
     def continue_to_next_stop(self):
@@ -600,3 +621,67 @@ class DAPTestCaseBase(TestBase):
         if response["success"]:
             self.verify_invalidated_event(["all"])
         return response
+
+    def _get_dap_server(
+        self, child_session_id: Optional[int] = None
+    ) -> dap_server.DebugAdapterServer:
+        """Get a specific DAP server instance.
+
+        Args:
+            child_session_id: Unique id of child session, or None for main session
+
+        Returns:
+            The requested DAP server instance
+        """
+        if child_session_id is None:
+            return self.dap_server
+        else:
+            child_sessions = self.dap_server.get_child_sessions()
+            if child_session_id not in child_sessions:
+                raise IndexError(f"Child session id {child_session_id} not found.")
+            return child_sessions[child_session_id]
+
+    def set_source_breakpoints_on(
+        self,
+        child_session_id: Optional[int],
+        source_path,
+        lines,
+        data=None,
+        wait_for_resolve=True,
+    ):
+        """Set source breakpoints on a specific DAP session without switching the active session."""
+        return self._set_source_breakpoints_impl(
+            self._get_dap_server(child_session_id),
+            Source(path=source_path),
+            lines,
+            data,
+            wait_for_resolve,
+        )
+
+    def verify_breakpoint_hit_on(
+        self, child_session_id: Optional[int], breakpoint_ids: list[str]
+    ):
+        """Verify breakpoint hit on a specific DAP session without switching the active session."""
+        return self._verify_breakpoint_hit_impl(
+            self._get_dap_server(child_session_id), breakpoint_ids
+        )
+
+    def do_continue_on(self, child_session_id: Optional[int]):
+        """Continue execution on a specific DAP session without switching the active session."""
+        return self._do_continue_impl(self._get_dap_server(child_session_id))
+
+    def start_server(self, connection):
+        """
+        Start an lldb-dap server process listening on the specified connection.
+        """
+        log_file_path = self.getBuildArtifact("dap.txt")
+        (process, connection) = dap_server.DebugAdapterServer.launch(
+            executable=self.lldbDAPExec, connection=connection, log_file=log_file_path
+        )
+
+        def cleanup():
+            process.terminate()
+
+        self.addTearDownHook(cleanup)
+
+        return (process, connection)

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1116,7 +1116,15 @@ Status ProcessGDBRemote::HandleConnectionRequest(const GPUActions &gpu_action) {
   if (!process_sp)
     return Status::FromErrorString("invalid process after connecting");
   LLDB_LOG(log, "ProcessGDBRemote::HandleConnectionRequest(): successfully "
-                "created process!!!");
+                "created process");
+  // Set the session name on the GPU target so it can be retrieved later
+  gpu_target_sp->SetTargetSessionName(gpu_action.session_name);
+  // Broadcast the target creation event so DAP can create a child session
+  auto event_sp = std::make_shared<Event>(
+      Target::eBroadcastBitNewTargetCreated,
+      new Target::TargetEventData(GetTarget().shared_from_this(),
+                                  gpu_target_sp));
+  GetTarget().BroadcastEvent(event_sp);
   return Status();
 }
 
@@ -5738,7 +5746,7 @@ llvm::Error ProcessGDBRemote::LoadModules() {
   ///   shared libraries are loaded.
   /// - Stop reason for a thread in GPU process is set to the
   ///   eStopReasonDynamicLoader stop reason. This is used when the GPU process
-  ///   eStopReasonDynamicLoaderzation with the native process. If the GPU
+  ///   needs synchronization with the native process. If the GPU
   ///   can't set a breakpoint in GPU code and the GPU driver gets a
   ///   notification that shared libraries are available. This should be used
   ///   if we want to stop for shared library loading and LLDB should auto

--- a/lldb/source/Utility/GPUGDBRemotePackets.cpp
+++ b/lldb/source/Utility/GPUGDBRemotePackets.cpp
@@ -170,6 +170,7 @@ bool fromJSON(const llvm::json::Value &value, GPUActions &data,
               llvm::json::Path path) {
   ObjectMapper o(value, path);
   return o && o.map("plugin_name", data.plugin_name) &&
+         o.map("session_name", data.session_name) &&
          o.map("identifier", data.identifier) &&
          o.mapOptional("stop_id", data.stop_id) &&
          o.map("breakpoints", data.breakpoints) &&
@@ -195,6 +196,7 @@ llvm::json::Value toJSON(const GPUActions &data) {
 
   return json::Value(Object{
       {"plugin_name", data.plugin_name},
+      {"session_name", data.session_name},
       {"identifier", data.identifier},
       {"stop_id", data.stop_id},
       {"breakpoints", data.breakpoints},

--- a/lldb/test/API/tools/lldb-dap/gpu/amd/Makefile
+++ b/lldb/test/API/tools/lldb-dap/gpu/amd/Makefile
@@ -1,0 +1,3 @@
+HIP_SOURCES := hello_world.hip
+
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/gpu/amd/TestDAP_gpu_reverse_request.py
+++ b/lldb/test/API/tools/lldb-dap/gpu/amd/TestDAP_gpu_reverse_request.py
@@ -1,0 +1,129 @@
+"""
+Test DAP reverse request functionality for GPU debugging.
+Tests the changes that allow creating new DAP targets through reverse requests,
+specifically for GPU debugging scenarios using AMD HIP.
+"""
+
+import dap_server
+import lldbdap_testcase
+from subprocess import Popen, PIPE
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestDAPAMDReverseRequest(lldbdap_testcase.DAPTestCaseBase):
+    """Test DAP session spawning - both basic and GPU scenarios"""
+
+    def test_automatic_reverse_request_detection(self):
+        """
+        Test that we can detect when LLDB automatically sends reverse requests
+        """
+        program = self.getBuildArtifact("a.out")
+
+        # Build and launch with settings that trigger reverse requests
+        self.build_and_launch(program)
+        source = "hello_world.hip"
+        breakpoint_line = line_number(source, "// CPU BREAKPOINT - BEFORE LAUNCH")
+        self.set_source_breakpoints(source, [breakpoint_line])
+        self.continue_to_next_stop()
+
+        reverse_request_count = len(self.dap_server.reverse_requests)
+        self.assertEqual(
+            reverse_request_count, 1, "Should have received one reverse request"
+        )
+
+        # Validate the startDebugging reverse request structure
+        req = self.dap_server.reverse_requests[0]
+
+        # Check command
+        self.assertIn("command", req, "Reverse request should have command")
+        self.assertEqual(
+            req["command"], "startDebugging", "Command should be startDebugging"
+        )
+
+        # Check arguments structure
+        self.assertIn("arguments", req, "Reverse request should have arguments")
+        args = req["arguments"]
+
+        # Check request type
+        self.assertIn("request", args, "Arguments should have request field")
+        self.assertEqual(args["request"], "attach", "Request type should be 'attach'")
+
+        # Check configuration
+        self.assertIn("configuration", args, "Arguments should have configuration")
+        config = args["configuration"]
+
+        # Check configuration.name (session name from GPU plugin)
+        self.assertIn("name", config, "Configuration should have name")
+        self.assertEqual(
+            config["name"],
+            "AMD GPU Session",
+            "Session name should be 'AMD GPU Session'",
+        )
+
+        # Check configuration.debuggerId (ID of existing debugger to reuse)
+        self.assertIn("debuggerId", config, "Configuration should have debuggerId")
+        self.assertIsInstance(
+            config["debuggerId"], int, "debuggerId should be an integer"
+        )
+
+        # Check configuration.targetId (ID of GPU target to attach to)
+        self.assertIn("targetId", config, "Configuration should have targetId")
+        self.assertIsInstance(config["targetId"], int, "targetId should be an integer")
+        self.assertGreater(config["targetId"], 1, "GPU target ID should be > 1")
+
+    def test_gpu_breakpoint_hit(self):
+        """
+        Test that we can hit a breakpoint in GPU debugging session spawned through reverse requests.
+        """
+        self.build()
+        log_file_path = self.getBuildArtifact("dap.txt")
+        # Enable detailed DAP logging to debug any issues
+        program = self.getBuildArtifact("a.out")
+        source = "hello_world.hip"
+        cpu_breakpoint_line = line_number(source, "// CPU BREAKPOINT")
+        gpu_breakpoint_line = line_number(source, "// GPU BREAKPOINT")
+        # Launch DAP server
+        _, connection = self.start_server(connection="listen://localhost:0")
+
+        self.dap_server = dap_server.DebugAdapterServer(
+            connection=connection, log_file=log_file_path
+        )
+        self.launch(
+            program,
+            disconnectAutomatically=False,
+        )
+
+        # Set CPU breakpoint and stop.
+        breakpoint_ids = self.set_source_breakpoints(source, [cpu_breakpoint_line])
+        self.continue_to_breakpoints(breakpoint_ids)
+        # We should have a GPU child session automatically spawned now
+        self.assertEqual(
+            len(self.dap_server.get_child_sessions()), 1, "Expected 1 child GPU session"
+        )
+
+        # Get the GPU target ID from the reverse request
+        self.assertEqual(
+            len(self.dap_server.reverse_requests),
+            1,
+            "Expected 1 startDebugging reverse request",
+        )
+        reverse_req = self.dap_server.reverse_requests[0]
+        gpu_target_id = reverse_req["arguments"]["configuration"]["targetId"]
+
+        # Set breakpoint in GPU session
+        gpu_breakpoint_ids = self.set_source_breakpoints_on(
+            gpu_target_id, source, [gpu_breakpoint_line], wait_for_resolve=False
+        )
+
+        # Continue both GPU and CPU sessions
+        self.do_continue_on(gpu_target_id)
+        self.do_continue()
+        # Verify that the GPU breakpoint is hit in the child session
+        self.verify_breakpoint_hit_on(gpu_target_id, gpu_breakpoint_ids)
+
+        # Manually disconnect sessions - must terminate debuggee to prevent
+        # orphaned processes that hang indefinitely waiting on GPU synchronization.
+        # Killing the main session will terminate the debuggee and the DAP server
+        # will automatically disconnect all child GPU sessions.
+        self.dap_server.request_disconnect(terminateDebuggee=True)

--- a/lldb/test/API/tools/lldb-dap/gpu/amd/hello_world.hip
+++ b/lldb/test/API/tools/lldb-dap/gpu/amd/hello_world.hip
@@ -1,0 +1,43 @@
+#include <hip/hip_runtime.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+constexpr int error_exit_code = -1;
+
+#define HIP_CHECK(condition)                                              \
+  {                                                                       \
+    const hipError_t error = (condition);                                 \
+    if (error != hipSuccess) {                                            \
+      fprintf(stderr, "HIP error: \"%s\" at %s:%d\n",                    \
+              hipGetErrorString(error), __FILE__, __LINE__);              \
+      exit(error_exit_code);                                              \
+    }                                                                     \
+  }
+
+__global__ void add_one(int *data) {
+    int idx = threadIdx.x;
+    data[idx] = idx + 1; // GPU BREAKPOINT
+}
+
+int main() {
+    const int n = 4;
+    int host_data[n] = {0, 0, 0, 0};
+    int *device_data;
+    printf("Starting GPU test...\n"); // CPU BREAKPOINT - BEFORE LAUNCH
+    // Allocate device memory
+    HIP_CHECK(hipMalloc(&device_data, n * sizeof(int)));
+    // Copy data to device
+    HIP_CHECK(hipMemcpy(device_data, host_data, n * sizeof(int), hipMemcpyHostToDevice));
+    // Launch kernel (single block, 4 threads)
+    add_one<<<1, n>>>(device_data);
+    // Check for kernel launch errors
+    HIP_CHECK(hipGetLastError());
+    // Wait for GPU to finish
+    HIP_CHECK(hipDeviceSynchronize());
+    // Copy results back to host
+    HIP_CHECK(hipMemcpy(host_data, device_data, n * sizeof(int), hipMemcpyDeviceToHost));
+    printf("Results: %d %d %d %d\n", host_data[0], host_data[1], host_data[2], host_data[3]); // CPU BREAKPOINT - AFTER LAUNCH
+    // Cleanup
+    HIP_CHECK(hipFree(device_data));
+    return 0;
+}

--- a/lldb/test/API/tools/lldb-dap/gpu/amd/lit.local.cfg
+++ b/lldb/test/API/tools/lldb-dap/gpu/amd/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "lldb-amdgpu" in config.enabled_plugins:
+    config.unsupported = True

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -90,6 +90,11 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
       error.SetErrorStringWithFormat("invalid target_id %lu in attach config",
                                      *target_id);
     }
+    // When attaching to an existing target (e.g., GPU target created by parent
+    // session), the process is likely already stopped at a breakpoint. Set
+    // stop_at_entry to prevent ConfigurationDone from continuing past the
+    // current stop.
+    dap.stop_at_entry = true;
   } else {
     target = dap.CreateTarget(error);
   }

--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -142,6 +142,7 @@ bool ThreadHasStopReason(lldb::SBThread &thread) {
   case lldb::eStopReasonHistoryBoundary:
     return true;
   case lldb::eStopReasonThreadExiting:
+  case lldb::eStopReasonDynamicLoader:
   case lldb::eStopReasonInvalid:
   case lldb::eStopReasonNone:
     break;

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -164,6 +164,10 @@ LLDBServerPluginAMDGPU::~LLDBServerPluginAMDGPU() { }
 
 llvm::StringRef LLDBServerPluginAMDGPU::GetPluginName() { return "amd-gpu"; }
 
+llvm::StringRef LLDBServerPluginAMDGPU::GetSessionName() {
+  return "AMD GPU Session";
+}
+
 Status LLDBServerPluginAMDGPU::InitializeAmdDbgApi() {
   LLDB_LOGF(GetLog(GDBRLog::Plugin), "%s called", __FUNCTION__);
 
@@ -463,6 +467,7 @@ bool LLDBServerPluginAMDGPU::ReadyToSetGpuLoaderBreakpointByAddress() {
 GPUActions LLDBServerPluginAMDGPU::SetConnectionInfo() {
   GPUActions actions = GetNewGPUAction();
   actions.connect_info = CreateConnection();
+  actions.session_name = GetSessionName();
   return actions;
 }
 

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.h
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.h
@@ -73,6 +73,7 @@ public:
   static void FreeDbgApiClientMemory(void *mem);
 
   bool CreateGPUBreakpoint(uint64_t addr);
+  llvm::StringRef GetSessionName();
 
   void GpuRuntimeDidLoad();
 

--- a/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/MockGPU/LLDBServerPluginMockGPU.cpp
@@ -209,6 +209,7 @@ LLDBServerPluginMockGPU::BreakpointWasHit(GPUPluginBreakpointHitArgs &args) {
     LLDB_LOGF(log, "LLDBServerPluginMockGPU::BreakpointWasHit(%u) disabling breakpoint", 
               bp_identifier);
     response.actions.connect_info = CreateConnection();
+    response.actions.session_name = "Mock GPU Session";
 
     // We asked for the symbol "gpu_shlib_load" to be delivered as a symbol
     // value when the "gpu_initialize" breakpoint was set. So we will use this

--- a/lldb/tools/lldb-server/Plugins/NVGPU/LLDBServerPluginNVGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/NVGPU/LLDBServerPluginNVGPU.cpp
@@ -102,6 +102,10 @@ LLDBServerPluginNVGPU::LLDBServerPluginNVGPU(
 
 llvm::StringRef LLDBServerPluginNVGPU::GetPluginName() { return "nvgpu"; }
 
+llvm::StringRef LLDBServerPluginNVGPU::GetSessionName() {
+  return "Nvidia GPU Session";
+}
+
 std::optional<GPUActions> LLDBServerPluginNVGPU::NativeProcessIsStopping() {
   return {};
 }
@@ -243,6 +247,7 @@ LLDBServerPluginNVGPU::BreakpointWasHit(GPUPluginBreakpointHitArgs &args) {
 
   GPUActions actions = GetNewGPUAction();
   actions.connect_info = std::move(*connection_info);
+  actions.session_name = GetSessionName();
   GPUPluginBreakpointHitResponse response(std::move(actions));
   response.disable_bp = true;
   return response;

--- a/lldb/tools/lldb-server/Plugins/NVGPU/LLDBServerPluginNVGPU.h
+++ b/lldb/tools/lldb-server/Plugins/NVGPU/LLDBServerPluginNVGPU.h
@@ -40,6 +40,8 @@ public:
   ///     String reference containing the plugin name.
   llvm::StringRef GetPluginName() override;
 
+  llvm::StringRef GetSessionName();
+
   /// Get the initialization actions required for this plugin.
   ///
   /// \return


### PR DESCRIPTION
## Summary
This takes the base changes from the plugin branch and adds one additional commit for NV-specific changes.
The only additional changes were:
- Implementing `GetSessionName()`;
- Adding `dap.stop_at_entry = true;` so the first GPU breakpoint doesn't get skipped.

## Testing
Hit CPU breakpoint:
<img width="1561" height="836" alt="Screenshot 2026-02-24 at 10 27 25 AM" src="https://github.com/user-attachments/assets/fcc4c844-c63d-42da-a578-7ece61042640" />
<img width="1486" height="822" alt="Screenshot 2026-02-24 at 10 29 38 AM" src="https://github.com/user-attachments/assets/d3b50068-c8e3-49f8-a8c9-c28683e3c952" />
Variables and Thread/Register view:
<img width="1428" height="822" alt="Screenshot 2026-02-24 at 10 30 19 AM" src="https://github.com/user-attachments/assets/4027eab5-160e-4ba1-aa18-361cbbd8b739" />
Continue to the next GPU breakpoint
<img width="1506" height="852" alt="Screenshot 2026-02-24 at 10 30 57 AM" src="https://github.com/user-attachments/assets/b5419a42-0cab-4d55-95c7-251801aedbc2" />


There's still some additional things to address (eg. GPU breakpoint not resolved at start so the top of the CPU section gets highlighted, vice versa when we're in the GPU target and hit a GPU breakpoint), which will fixed later.