### PR TITLE
Fix triton debugging memory module overwrite each other issue

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -534,6 +534,8 @@ public:
 
   uint64_t GetObjectOffset() const { return m_object_offset; }
 
+  uint64_t GetObjectSize() const { return m_object_size; }
+
   /// Get the object file representation for the current architecture.
   ///
   /// If the object file has not been located or parsed yet, this function
@@ -1023,6 +1025,7 @@ protected:
                              /// selected, or empty of the module is represented
                              /// by \a m_file.
   uint64_t m_object_offset = 0;
+  uint64_t m_object_size = 0;
   llvm::sys::TimePoint<> m_object_mod_time;
 
   /// DataBuffer containing the module image, if it was provided at

--- a/lldb/include/lldb/Utility/AmdGpuCoreUtils.h
+++ b/lldb/include/lldb/Utility/AmdGpuCoreUtils.h
@@ -44,7 +44,7 @@ struct AmdGpuCodeObject {
 ///
 /// For file:// URIs, pathname is set to the real file path so that LLDB can
 /// locate files on disk and resolve dwp/dwo debug info.
-/// For memory:// URIs, pathname is set to "<memory>[start, end)" for
+/// For memory:// URIs, pathname is set to "amd_memory_kernel[start, end)" for
 /// uniqueness (memory modules are not used for file probing).
 ///
 /// \param[in] code_object

--- a/lldb/include/lldb/Utility/AmdGpuCoreUtils.h
+++ b/lldb/include/lldb/Utility/AmdGpuCoreUtils.h
@@ -42,6 +42,11 @@ struct AmdGpuCodeObject {
 ///   - file://<path>#offset=<file-offset>&size=<file-size>
 ///   - memory://<name>#offset=<image-addr>&size=<image-size>
 ///
+/// For file:// URIs, pathname is set to the real file path so that LLDB can
+/// locate files on disk and resolve dwp/dwo debug info.
+/// For memory:// URIs, pathname is set to "<memory>[start, end)" for
+/// uniqueness (memory modules are not used for file probing).
+///
 /// \param[in] code_object
 ///     The AMD GPU code object structure containing URI and load information.
 ///

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -3379,6 +3379,14 @@ protected:
     }
 
     bool dump_object_name = false;
+    auto dump_object_offset_range = [&module, &strm]() {
+      if (!module->GetObjectName() && module->GetObjectOffset() > 0 &&
+          module->GetObjectSize() > 0) {
+        uint64_t offset = module->GetObjectOffset();
+        uint64_t end = offset + module->GetObjectSize();
+        strm.Printf("[%#" PRIx64 "-%#" PRIx64 ")", offset, end);
+      }
+    };
     if (m_options.m_format_array.empty()) {
       m_options.m_format_array.push_back(std::make_pair('u', 0));
       m_options.m_format_array.push_back(std::make_pair('h', 0));
@@ -3404,15 +3412,8 @@ protected:
 
       case 'f':
         DumpFullpath(strm, &module->GetFileSpec(), width);
-        // Append byte range for embedded objects (e.g. GPU modules within a
-        // container binary) that don't have a named object.
-        if (!module->GetObjectName() && module->GetObjectOffset() > 0 &&
-            module->GetObjectSize() > 0) {
-          uint64_t offset = module->GetObjectOffset();
-          uint64_t end = offset + module->GetObjectSize();
-          strm.Printf("[%#" PRIx64 "-%#" PRIx64 ")", offset, end);
-        }
         dump_object_name = true;
+        dump_object_offset_range();
         break;
 
       case 'd':
@@ -3421,13 +3422,8 @@ protected:
 
       case 'b':
         DumpBasename(strm, &module->GetFileSpec(), width);
-        if (!module->GetObjectName() && module->GetObjectOffset() > 0 &&
-            module->GetObjectSize() > 0) {
-          uint64_t offset = module->GetObjectOffset();
-          uint64_t end = offset + module->GetObjectSize();
-          strm.Printf("[%#" PRIx64 "-%#" PRIx64 ")", offset, end);
-        }
         dump_object_name = true;
+        dump_object_offset_range();
         break;
 
       case 'h':

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -3404,6 +3404,14 @@ protected:
 
       case 'f':
         DumpFullpath(strm, &module->GetFileSpec(), width);
+        // Append byte range for embedded objects (e.g. GPU modules within a
+        // container binary) that don't have a named object.
+        if (!module->GetObjectName() && module->GetObjectOffset() > 0 &&
+            module->GetObjectSize() > 0) {
+          uint64_t offset = module->GetObjectOffset();
+          uint64_t end = offset + module->GetObjectSize();
+          strm.Printf("[%#" PRIx64 "-%#" PRIx64 ")", offset, end);
+        }
         dump_object_name = true;
         break;
 
@@ -3413,6 +3421,12 @@ protected:
 
       case 'b':
         DumpBasename(strm, &module->GetFileSpec(), width);
+        if (!module->GetObjectName() && module->GetObjectOffset() > 0 &&
+            module->GetObjectSize() > 0) {
+          uint64_t offset = module->GetObjectOffset();
+          uint64_t end = offset + module->GetObjectSize();
+          strm.Printf("[%#" PRIx64 "-%#" PRIx64 ")", offset, end);
+        }
         dump_object_name = true;
         break;
 

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -231,6 +231,7 @@ Module::Module(const ModuleSpec &module_spec)
   // (for mod time in a BSD static archive) of from the matching module
   // specification
   m_object_offset = matching_module_spec.GetObjectOffset();
+  m_object_size = matching_module_spec.GetObjectSize();
   m_object_mod_time = matching_module_spec.GetObjectModificationTime();
 }
 
@@ -1023,6 +1024,9 @@ std::string Module::GetSpecificationDescription() const {
     spec += '(';
     spec += m_object_name.GetCString();
     spec += ')';
+  } else if (m_object_offset > 0 && m_object_size > 0) {
+    spec += llvm::formatv("[{0}-{1})", llvm::format_hex(m_object_offset, 1),
+                          llvm::format_hex(m_object_offset + m_object_size, 1));
   }
   return spec;
 }
@@ -1047,6 +1051,9 @@ void Module::GetDescription(llvm::raw_ostream &s,
   const char *object_name = m_object_name.GetCString();
   if (object_name)
     s << llvm::formatv("({0})", object_name);
+  else if (m_object_offset > 0 && m_object_size > 0)
+    s << llvm::formatv("[{0}-{1})", llvm::format_hex(m_object_offset, 1),
+                       llvm::format_hex(m_object_offset + m_object_size, 1));
 }
 
 bool Module::FileHasChanged() const {

--- a/lldb/source/Plugins/DynamicLoader/GDBRemoteGPU/DynamicLoaderGDBRemoteGPU.cpp
+++ b/lldb/source/Plugins/DynamicLoader/GDBRemoteGPU/DynamicLoaderGDBRemoteGPU.cpp
@@ -131,9 +131,6 @@ bool DynamicLoaderGDBRemoteGPU::LoadModulesFromGDBServer(bool full) {
     if (info.uuid_str)
       uuid.SetFromStringRef(*info.uuid_str);
     // Create a module specification from the info we got.
-    // Use pathname (the real file path) for the FileSpec so LLDB can locate
-    // the file on disk for file-backed modules. For memory modules, pathname
-    // is already set to "<memory>[start, end)" format for uniqueness.
     ModuleSpec module_spec(FileSpec(info.pathname), uuid, data_sp);
     if (info.file_offset)
       module_spec.SetObjectOffset(*info.file_offset);

--- a/lldb/source/Plugins/DynamicLoader/GDBRemoteGPU/DynamicLoaderGDBRemoteGPU.cpp
+++ b/lldb/source/Plugins/DynamicLoader/GDBRemoteGPU/DynamicLoaderGDBRemoteGPU.cpp
@@ -131,6 +131,9 @@ bool DynamicLoaderGDBRemoteGPU::LoadModulesFromGDBServer(bool full) {
     if (info.uuid_str)
       uuid.SetFromStringRef(*info.uuid_str);
     // Create a module specification from the info we got.
+    // Use pathname (the real file path) for the FileSpec so LLDB can locate
+    // the file on disk for file-backed modules. For memory modules, pathname
+    // is already set to "<memory>[start, end)" format for uniqueness.
     ModuleSpec module_spec(FileSpec(info.pathname), uuid, data_sp);
     if (info.file_offset)
       module_spec.SetObjectOffset(*info.file_offset);

--- a/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
@@ -413,9 +413,6 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
     }
 
     // Create a module specification from the info we got.
-    // Use pathname (the real file path) for the FileSpec so LLDB can locate
-    // the file on disk for file-backed modules. For memory modules, pathname
-    // is already set to "<memory>[start, end)" format for uniqueness.
     UUID uuid;
     ModuleSpec module_spec(FileSpec(lib_info->pathname), uuid, data_sp);
 

--- a/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
@@ -412,7 +412,10 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
       }
     }
 
-    // Create a module specification from the info we got
+    // Create a module specification from the info we got.
+    // Use pathname (the real file path) for the FileSpec so LLDB can locate
+    // the file on disk for file-backed modules. For memory modules, pathname
+    // is already set to "<memory>[start, end)" format for uniqueness.
     UUID uuid;
     ModuleSpec module_spec(FileSpec(lib_info->pathname), uuid, data_sp);
 

--- a/lldb/source/Utility/AmdGpuCoreUtils.cpp
+++ b/lldb/source/Utility/AmdGpuCoreUtils.cpp
@@ -21,7 +21,7 @@ lldb_private::ParseLibraryInfo(const AmdGpuCodeObject &code_object) {
   //
   // For file:// URIs, pathname is set to the real file path so LLDB can locate
   // the file on disk and resolve dwp/dwo debug info.
-  // For memory:// URIs, pathname is set to "<memory>[start, end)" for
+  // For memory:// URIs, pathname is set to "amd_memory_kernel[start, end)" for
   // uniqueness since memory modules are not used for file probing.
   GPUDynamicLoaderLibraryInfo lib_info;
   lib_info.load = code_object.is_loaded;
@@ -66,12 +66,10 @@ lldb_private::ParseLibraryInfo(const AmdGpuCodeObject &code_object) {
     if (!(lib_info.native_memory_address.has_value() &&
           lib_info.native_memory_size.has_value()))
       return std::nullopt;
-    // Set the pathname to a unique "<memory>[start, end)" format.
-    // Memory modules won't be used for file probing anyway.
     uint64_t start = *lib_info.native_memory_address;
     uint64_t end = start + *lib_info.native_memory_size;
     lib_info.pathname =
-        llvm::formatv("<memory>[{0}, {1})", llvm::format_hex(start, 1),
+        llvm::formatv("amd_memory_kernel[{0}, {1})", llvm::format_hex(start, 1),
                       llvm::format_hex(end, 1));
   } else {
     return std::nullopt;

--- a/lldb/source/Utility/AmdGpuCoreUtils.cpp
+++ b/lldb/source/Utility/AmdGpuCoreUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Utility/AmdGpuCoreUtils.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FormatVariadic.h"
 
 using namespace lldb_private;
 
@@ -17,6 +18,11 @@ lldb_private::ParseLibraryInfo(const AmdGpuCodeObject &code_object) {
   // sends to the debugger. The format is one of:
   //  file://<path>#offset=<file-offset>&size=<file-size>
   //  memory://<name>#offset=<image-addr>&size=<image-size>
+  //
+  // For file:// URIs, pathname is set to the real file path so LLDB can locate
+  // the file on disk and resolve dwp/dwo debug info.
+  // For memory:// URIs, pathname is set to "<memory>[start, end)" for
+  // uniqueness since memory modules are not used for file probing.
   GPUDynamicLoaderLibraryInfo lib_info;
   lib_info.load = code_object.is_loaded;
   lib_info.load_address = code_object.load_address;
@@ -54,13 +60,19 @@ lldb_private::ParseLibraryInfo(const AmdGpuCodeObject &code_object) {
     std::tie(name, values) = lib_spec.split('#');
     if (name.empty())
       return std::nullopt;
-    lib_info.pathname = name.str();
     get_offset_and_size(values, lib_info.native_memory_address,
                         lib_info.native_memory_size);
     // We must have a valid address and size for memory objects.
     if (!(lib_info.native_memory_address.has_value() &&
           lib_info.native_memory_size.has_value()))
       return std::nullopt;
+    // Set the pathname to a unique "<memory>[start, end)" format.
+    // Memory modules won't be used for file probing anyway.
+    uint64_t start = *lib_info.native_memory_address;
+    uint64_t end = start + *lib_info.native_memory_size;
+    lib_info.pathname =
+        llvm::formatv("<memory>[{0}, {1})", llvm::format_hex(start, 1),
+                      llvm::format_hex(end, 1));
   } else {
     return std::nullopt;
   }

--- a/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
@@ -123,19 +123,19 @@ class BasicAmdGpuTestCase(AmdGpuTestCaseBase):
         # There should be one module loaded from the executable (the kernel) and one
         # loaded from memory (driver/debugger lib code).
         # File-backed modules keep their original file path (e.g. /path/to/a.out).
-        # Memory-backed modules are named: <memory>[start, end)
+        # Memory-backed modules are named: amd_memory_kernel[start, end)
         gpu_modules = self.gpu_target.modules
         self.assertEqual(2, len(gpu_modules), "GPU should have two modules")
 
         # Check that one module contains "a.out" (file-backed, keeps original path)
-        # and one starts with "<memory>[" (memory-backed).
+        # and one starts with "amd_memory_kernel[" (memory-backed).
         module_names = [str(module.file) for module in gpu_modules]
         has_file_module = any("a.out" in name for name in module_names)
-        has_memory_module = any("<memory>[" in name for name in module_names)
+        has_memory_module = any("amd_memory_kernel[" in name for name in module_names)
         self.assertTrue(has_file_module,
                         f"Expected a file-backed module with 'a.out' in path, got: {module_names}")
         self.assertTrue(has_memory_module,
-                        f"Expected a memory-backed module with '<memory>[' prefix, got: {module_names}")
+                        f"Expected a memory-backed module with 'amd_memory_kernel[' prefix, got: {module_names}")
 
         # Verify the "image list" command output shows the [offset-end) bracket
         # for the file-backed embedded GPU module (no space before the bracket).
@@ -151,6 +151,6 @@ class BasicAmdGpuTestCase(AmdGpuTestCaseBase):
         has_bracket_format = re.search(r'a\.out\[0x[0-9a-f]+-0x[0-9a-f]+\)', output)
         self.assertTrue(has_bracket_format,
                         f"Expected 'a.out[offset-end)' format in image list output, got:\n{output}")
-        # Memory-backed module should show <memory>[start, end)
-        self.assertIn("<memory>[", output,
-                      f"Expected '<memory>[' in image list output, got:\n{output}")
+        # Memory-backed module should show amd_memory_kernel[start, end)
+        self.assertIn("amd_memory_kernel[", output,
+                      f"Expected 'amd_memory_kernel[' in image list output, got:\n{output}")

--- a/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
@@ -121,14 +121,36 @@ class BasicAmdGpuTestCase(AmdGpuTestCaseBase):
 
         # There should two modules loaded for the gpu.
         # There should be one module loaded from the executable (the kernel) and one
-        # loaded from memory (driver/debugger lib code). The in-memory module name is the
-        # same as the cpu process id.
+        # loaded from memory (driver/debugger lib code).
+        # File-backed modules keep their original file path (e.g. /path/to/a.out).
+        # Memory-backed modules are named: <memory>[start, end)
         gpu_modules = self.gpu_target.modules
         self.assertEqual(2, len(gpu_modules), "GPU should have two modules")
 
-        # Check for the expected modules but allow them to be in any order.
-        exe = "a.out"
-        pid = str(self.cpu_process.GetProcessID())
-        module_files = [module.file.basename for module in gpu_modules]
-        self.assertIn(exe, module_files)
-        self.assertIn(pid, module_files)
+        # Check that one module contains "a.out" (file-backed, keeps original path)
+        # and one starts with "<memory>[" (memory-backed).
+        module_names = [str(module.file) for module in gpu_modules]
+        has_file_module = any("a.out" in name for name in module_names)
+        has_memory_module = any("<memory>[" in name for name in module_names)
+        self.assertTrue(has_file_module,
+                        f"Expected a file-backed module with 'a.out' in path, got: {module_names}")
+        self.assertTrue(has_memory_module,
+                        f"Expected a memory-backed module with '<memory>[' prefix, got: {module_names}")
+
+        # Verify the "image list" command output shows the [offset-end) bracket
+        # for the file-backed embedded GPU module (no space before the bracket).
+        # Select GPU target so the command runs against it.
+        self.dbg.SetSelectedTarget(self.gpu_target)
+        interp = self.dbg.GetCommandInterpreter()
+        result = lldb.SBCommandReturnObject()
+        interp.HandleCommand("image list", result)
+        output = result.GetOutput()
+        self.assertTrue(result.Succeeded(), f"image list failed: {result.GetError()}")
+        # File-backed module should show path[0x...-0x...) with no space before bracket.
+        import re
+        has_bracket_format = re.search(r'a\.out\[0x[0-9a-f]+-0x[0-9a-f]+\)', output)
+        self.assertTrue(has_bracket_format,
+                        f"Expected 'a.out[offset-end)' format in image list output, got:\n{output}")
+        # Memory-backed module should show <memory>[start, end)
+        self.assertIn("<memory>[", output,
+                      f"Expected '<memory>[' in image list output, got:\n{output}")


### PR DESCRIPTION
While trying to use lldb to debug triton target, I noticed that it failed to recognize the crashing triton kernel functions during stack unwinding. Turns out the triton kernels are placed in GPU memory modules. Our old design uses <pid> as module name for memory modules which means if there are multiple memory modules, they will overwrite each other due to the same signature (name).

This PR fixes the issue with two changes:
  1. Memory modules now use a unique <memory>[start, end) pathname format, preventing module overwrites. This path is set at parse time and won't be used for file probing anyway.
  2. File-backed embedded GPU modules keep their original file path unchanged (e.g. /tmp/app/a.out). The image list command shows path[offset-end) to distinguish embedded modules, but the underlying FileSpec is preserved so LLDB can still locate and resolve dwp/dwo split-dwarf debug info files.

Triton kernel symbolication now works:
```
  * thread #1, name = 'AMD GPU Thread', stop reason = signal SIGTRAP
    * frame #0: 0x00007fa643c1d7cc <memory>[0x7f66189a0420, 0x7f66189a1dc0)`triton_ima_kernel at ima_triton_kernel.py:28:17 [inlined]
      frame #1: 0x00007fa643c1d798 <memory>[0x7f66189a0420, 0x7f66189a1dc0)`triton_ima_kernel at ima_triton_kernel.py:55:60
```

And GPU module list:
```
  (lldb) image list
  [  0] BA542BA4 0x00007ffff5ea0000 /tmp/gpu_split_dwarf_test/amd_gpu_scenario_generator[0x13000-0x2fe08)
  [  1] EE35B314 0x00007ffff5e70000 <memory>[0x11d14e0, 0x11d8570)
```
