### PR TITLE
Add placeholder module support for AMD GPU core file debugging

### DIFF
--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -3517,6 +3517,11 @@ protected:
       if (object_name)
         strm.Printf("(%s)", object_name);
     }
+    // Mark placeholder modules so users can identify missing binaries
+    if (ObjectFile *obj = module->GetObjectFile()) {
+      if (obj->GetPluginName() == "placeholder")
+        strm.PutCString(" (*)");
+    }
     strm.EOL();
   }
 

--- a/lldb/source/Plugins/Process/amdgpu-core/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/amdgpu-core/CMakeLists.txt
@@ -24,6 +24,7 @@ add_lldb_library(lldbPluginProcessAmdGpuCore PLUGIN
     lldbTarget
     lldbPluginObjectFileELF
     lldbPluginProcessUtility
+    lldbPluginObjectFilePlaceholder
     lldbPluginProcessElfCore
     amd-dbgapi
   )

--- a/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 
 #include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
+#include "Plugins/ObjectFile/Placeholder/ObjectFilePlaceholder.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
@@ -390,25 +391,22 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
                native_mem_addr);
 
       TargetSP cpu_target_sp = target.GetNativeTargetForGPU();
-      if (!cpu_target_sp) {
-        LLDB_LOG(log, "Invalid CPU target for \"{0}\" from memory at {1:x}",
-                 lib_info->pathname, native_mem_addr);
-        continue;
-      }
-      ProcessSP cpu_process_sp = cpu_target_sp->GetProcessSP();
-      if (!cpu_process_sp) {
-        LLDB_LOG(log, "Invalid CPU process for \"{0}\" from memory at {1:x}",
-                 lib_info->pathname, native_mem_addr);
-        continue;
-      }
-      data_sp = std::make_shared<DataBufferHeap>(native_mem_size, 0);
-      Status error;
-      const size_t bytes_read = cpu_process_sp->ReadMemory(
-          native_mem_addr, data_sp->GetBytes(), data_sp->GetByteSize(), error);
-      if (bytes_read != native_mem_size) {
-        LLDB_LOG(log, "Failed to read \"{0}\" from memory at {1:x}: {2}",
-                 lib_info->pathname, native_mem_addr, error);
-        continue;
+      ProcessSP cpu_process_sp =
+          cpu_target_sp ? cpu_target_sp->GetProcessSP() : nullptr;
+      if (cpu_process_sp) {
+        data_sp = std::make_shared<DataBufferHeap>(native_mem_size, 0);
+        Status error;
+        const size_t bytes_read = cpu_process_sp->ReadMemory(
+            native_mem_addr, data_sp->GetBytes(), data_sp->GetByteSize(),
+            error);
+        if (bytes_read != native_mem_size) {
+          LLDB_LOG(log, "Failed to read \"{0}\" from memory at {1:x}: {2}",
+                   lib_info->pathname, native_mem_addr, error);
+          data_sp.reset(); // Fall through to try file or placeholder
+        }
+      } else {
+        LLDB_LOG(log, "No CPU process available to read \"{0}\" from memory",
+                 lib_info->pathname);
       }
     }
 
@@ -425,6 +423,34 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
     // Get or create the module from the module spec
     ModuleSP module_sp = target.GetOrCreateModule(module_spec,
                                                   /*notify=*/true);
+    if (!module_sp) {
+      // The module file could not be found on disk. Create a placeholder
+      // module so it still shows up in "image list" and can be re-hydrated
+      // later (e.g. via a symbol server).
+      lldb::addr_t load_addr = lib_info->load_address.value_or(0);
+      lldb::addr_t load_size =
+          lib_info->native_memory_size.value_or(
+              lib_info->file_size.value_or(0));
+      if (load_size > 0) {
+        LLDB_LOG(log,
+                 "Unable to locate module file, creating placeholder for: "
+                 "{0} (addr={1:x}, size={2})",
+                 lib_info->pathname, load_addr, load_size);
+        // Set the architecture so ObjectFilePlaceholder::GetArchitecture()
+        // returns a valid ArchSpec (required by CreateModuleFromObjectFile).
+        module_spec.GetArchitecture() = target.GetArchitecture();
+        module_sp = Module::CreateModuleFromObjectFile<ObjectFilePlaceholder>(
+            module_spec, load_addr, load_size);
+        if (module_sp) {
+          target.GetImages().Append(module_sp, /*notify=*/true);
+        }
+      } else {
+        LLDB_LOG(log, "Unable to locate module file and no size info "
+                      "available for placeholder: {0}",
+                 lib_info->pathname);
+      }
+    }
+
     if (module_sp) {
       LLDB_LOG(log, "Created module for \"{0}\": {1:x}", lib_info->pathname,
                module_sp.get());
@@ -433,8 +459,13 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
                lib_info->pathname, lib_info->load_address.value_or(0));
 
       if (lib_info->load_address.has_value()) {
+        // ObjectFilePlaceholder::SetLoadAddress asserts value_is_offset=false
+        // because it uses absolute addresses for its section.
+        bool is_placeholder =
+            module_sp->GetObjectFile() &&
+            module_sp->GetObjectFile()->GetPluginName() == "placeholder";
         module_sp->SetLoadAddress(target, lib_info->load_address.value(),
-                                  /*value_is_offset=*/true, changed);
+                                  /*value_is_offset=*/!is_placeholder, changed);
         if (changed) {
           LLDB_LOG(log, "Module \"{0}\" was loaded", lib_info->pathname);
           loaded_modules.AppendIfNeeded(module_sp);

--- a/lldb/test/API/gpu/amd/core/TestAmdGpuCorePlaceholderModule.py
+++ b/lldb/test/API/gpu/amd/core/TestAmdGpuCorePlaceholderModule.py
@@ -1,0 +1,105 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""
+Test AMD GPU core file placeholder module support.
+
+When a GPU code object's binary cannot be found on disk or read from memory,
+a placeholder module should be created so it still appears in 'image list'
+and can later be re-hydrated (e.g. via a symbol server).
+
+This test generates a GPU core via rocgdb, then deletes the binary so that
+file-backed code objects become unfindable. The placeholder module support
+should create placeholder modules for those missing code objects.
+"""
+
+import lldb
+import os
+from lldbsuite.test.decorators import *
+from lldbsuite.test.tools.gpu.amdgpu_core_testbase import AmdGpuCoreTestBase
+
+
+class TestAmdGpuCorePlaceholderModule(AmdGpuCoreTestBase):
+    """Test placeholder modules for missing GPU code objects in core files"""
+
+    HIP_SOURCE = "variables.hip"
+    GPU_BREAKPOINT_PATTERN = "// GPU BREAKPOINT"
+
+    @skipIfRemote
+    def test_placeholder_modules_created_for_missing_files(self):
+        """Test that placeholder modules are created when code object files
+        cannot be found on disk."""
+        # Delete the binary BEFORE loading the core so file-backed code
+        # objects can't be found and must become placeholders.
+        binary_path = self.getBuildArtifact("a.out")
+        self.assertTrue(
+            os.path.isfile(binary_path),
+            f"Binary should exist at {binary_path}",
+        )
+        os.remove(binary_path)
+
+        # Load the core — file-backed code objects should get placeholder
+        # modules instead of being silently dropped.
+        gpu_target, gpu_process = self.load_core()
+        num_modules = gpu_target.GetNumModules()
+
+        self.assertGreater(
+            num_modules,
+            0,
+            "GPU target should have at least one module",
+        )
+
+        # Verify at least one module is a placeholder (no UUID) and at least
+        # one is a real module (has UUID). Memory-backed code objects (e.g.
+        # amd_memory_kernel) are read from core memory and produce real ELF
+        # modules with UUIDs. File-backed code objects whose binary was
+        # deleted should produce placeholders without UUIDs.
+        modules_with_uuid = 0
+        modules_without_uuid = 0
+        for i in range(num_modules):
+            module = gpu_target.GetModuleAtIndex(i)
+            self.assertTrue(
+                module.IsValid(), f"Module at index {i} should be valid"
+            )
+            filename = module.GetFileSpec().GetFilename()
+            self.assertIsNotNone(
+                filename, f"Module at index {i} should have a filename"
+            )
+
+            uuid = module.GetUUIDString()
+            if uuid and len(uuid) > 0:
+                modules_with_uuid += 1
+            else:
+                modules_without_uuid += 1
+
+            # Every module (real or placeholder) should have at least one
+            # section with a valid load address.
+            num_sections = module.GetNumSections()
+            self.assertGreater(
+                num_sections,
+                0,
+                f"Module '{filename}' should have at least one section",
+            )
+            has_valid_load_addr = False
+            for j in range(num_sections):
+                section = module.GetSectionAtIndex(j)
+                load_addr = section.GetLoadAddress(gpu_target)
+                if load_addr != lldb.LLDB_INVALID_ADDRESS:
+                    has_valid_load_addr = True
+                    break
+            self.assertTrue(
+                has_valid_load_addr,
+                f"Module '{filename}' should have a valid load address",
+            )
+
+        self.assertGreater(
+            modules_with_uuid,
+            0,
+            "Should have at least one real module (with UUID) "
+            "from memory-backed code objects",
+        )
+        self.assertGreater(
+            modules_without_uuid,
+            0,
+            "Should have at least one placeholder module (without UUID) "
+            "for missing code object files",
+        )


### PR DESCRIPTION
When a GPU code object's binary cannot be found on disk or read from memory the module list won't show it. This PR create a placeholder module (ObjectFilePlaceholder) instead of silently dropping it. This ensures all code objects appear in 'image list' and can later be re-hydrated via a symbol server.

Changes:
- ProcessAmdGpuCore: Create placeholder modules for missing code objects, set architecture on module spec, handle value_is_offset correctly for placeholder vs real modules
- CMakeLists.txt: Add lldbPluginObjectFilePlaceholder link dependency
- CommandObjectTarget: Mark placeholder modules with (*) in 'image list'
- Add test that generates a GPU core, deletes the binary, and verifies placeholder modules are created for the missing file-backed code objects