### PR TITLE
Speed up GPU register test by sampling representative indices

### DIFF
--- a/lldb/test/API/gpu/amd/register/TestRegisterAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/register/TestRegisterAmdGpuPlugin.py
@@ -39,26 +39,36 @@ class RegisterAmdGpuTestCase(AmdGpuTestCaseBase):
     def test_agrp_lane_write(self):
         self.do_lane_read_write_test("a", NUM_ACCUM_REGISTERS)
 
+    @staticmethod
+    def _sample_indices(count):
+        """Return a small representative set of indices: first, middle, last."""
+        indices = {0, count // 2, count - 1}
+        return sorted(indices)
+
     def do_reg_read_write_test(self, reg_base, num_regs):
-        """Verify we can read and write the whole register value"""
+        """Verify we can read and write the whole register value.
+        Tests a representative sample of registers (first, middle, last)
+        instead of all registers to keep test times reasonable."""
         self.build()
         self.run_to_reg_gpu_breakpoint(reg_base)
 
-        for i in range(num_regs):
+        for i in self._sample_indices(num_regs):
             reg, known_value, new_value = self.get_test_values(reg_base, i, num_regs)
             self.verify_reg_read_and_write(reg, known_value, new_value)
 
     def do_lane_read_write_test(self, reg_base, num_regs):
-        """Verify we can read and write the individual lanes of a register"""
+        """Verify we can read and write the individual lanes of a register.
+        Tests a representative sample of registers and lanes (first, middle,
+        last) instead of all combinations to keep test times reasonable."""
         self.build()
         self.run_to_reg_gpu_breakpoint(reg_base)
 
-        for i in range(num_regs):
+        for i in self._sample_indices(num_regs):
             reg = f"{reg_base}{i}"
             new_value = [0] * WAVE_SIZE
             self.verify_reg_write(reg, new_value)
 
-            for lane in range(WAVE_SIZE):
+            for lane in self._sample_indices(WAVE_SIZE):
                 new_value[lane] = self.replicate_byte(lane + 1)
                 self.verify_reg_write(reg, new_value)
 

--- a/lldb/test/API/gpu/amd/register/TestRegisterAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/register/TestRegisterAmdGpuPlugin.py
@@ -2,6 +2,8 @@
 Register tests for the AMDGPU plugin.
 """
 
+import os
+
 import lldb
 from amdgpu_testcase import AmdGpuTestCaseBase
 import lldbsuite.test.lldbutil as lldbutil
@@ -41,14 +43,16 @@ class RegisterAmdGpuTestCase(AmdGpuTestCaseBase):
 
     @staticmethod
     def _sample_indices(count):
-        """Return a small representative set of indices: first, middle, last."""
-        indices = {0, count // 2, count - 1}
-        return sorted(indices)
+        """Return indices to test. By default returns a small representative
+        set (first, middle, last). Set LLDB_TEST_EXHAUSTIVE=1 to test all."""
+        if os.environ.get("LLDB_TEST_EXHAUSTIVE"):
+            return list(range(count))
+        return sorted({0, count // 2, count - 1})
 
     def do_reg_read_write_test(self, reg_base, num_regs):
         """Verify we can read and write the whole register value.
         Tests a representative sample of registers (first, middle, last)
-        instead of all registers to keep test times reasonable."""
+        by default. Set LLDB_TEST_EXHAUSTIVE=1 to test all registers."""
         self.build()
         self.run_to_reg_gpu_breakpoint(reg_base)
 
@@ -59,7 +63,7 @@ class RegisterAmdGpuTestCase(AmdGpuTestCaseBase):
     def do_lane_read_write_test(self, reg_base, num_regs):
         """Verify we can read and write the individual lanes of a register.
         Tests a representative sample of registers and lanes (first, middle,
-        last) instead of all combinations to keep test times reasonable."""
+        last) by default. Set LLDB_TEST_EXHAUSTIVE=1 to test all."""
         self.build()
         self.run_to_reg_gpu_breakpoint(reg_base)
 

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -355,6 +355,10 @@ if "FREEBSD_LEGACY_PLUGIN" in os.environ:
 if "XDG_CACHE_HOME" in os.environ:
     config.environment["XDG_CACHE_HOME"] = os.environ["XDG_CACHE_HOME"]
 
+# Propagate LLDB_TEST_EXHAUSTIVE for running exhaustive/long-running tests.
+if "LLDB_TEST_EXHAUSTIVE" in os.environ:
+    config.environment["LLDB_TEST_EXHAUSTIVE"] = os.environ["LLDB_TEST_EXHAUSTIVE"]
+
 # Transfer some environment variables into the tests on Windows build host.
 if platform.system() == "Windows":
     for v in ["SystemDrive"]:


### PR DESCRIPTION
The register test was the slowest GPU test at ~86s, blocking parallel test execution. The lane write tests iterated all 256 registers x 64 lanes (~65,000 LLDB command round-trips). This reduces iteration to first/middle/last indices for both registers and lanes, cutting the test from 86s to ~29s while still exercising boundary and middle cases.

Test plan:
- All 10 GPU AMD tests pass.
- Register test time: 86s -> 29s.
- Total suite time: 137s -> 31s (register test no longer blocks parallel execution).