### PR TITLE
Fix ninja test failures in GPU DAP reverse request tests (#91)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -220,6 +220,7 @@ class DebugCommunication(object):
         # changes.
         self._recv_condition = threading.Condition()
         self._recv_thread = threading.Thread(target=self._read_packet_thread)
+        self._recv_thread.daemon = True
 
         # session state
         self.init_commands = init_commands if init_commands else []
@@ -1657,7 +1658,14 @@ class DebugAdapterServer(DebugCommunication):
         """Handle startDebugging reverse request by creating child DAP sessions.
 
         This override creates child DAP sessions for GPU debugging.
+        When no connection is available (stdio mode), falls back to the base
+        class behavior of just acknowledging the request.
         """
+        if self.connection is None:
+            # In stdio mode, we can't create child sessions over the same
+            # connection. Fall back to base class which just sends success.
+            super()._handle_startDebugging_request(request)
+            return
         try:
             arguments = request.get("arguments", {})
             request_type = arguments.get("request", "attach")

--- a/lldb/test/API/tools/lldb-dap/gpu/amd/TestDAP_gpu_reverse_request.py
+++ b/lldb/test/API/tools/lldb-dap/gpu/amd/TestDAP_gpu_reverse_request.py
@@ -20,10 +20,12 @@ class TestDAPAMDReverseRequest(lldbdap_testcase.DAPTestCaseBase):
         """
         program = self.getBuildArtifact("a.out")
 
-        # Build and launch with settings that trigger reverse requests
+        # Build and launch with settings that trigger reverse requests.
+        # The breakpoint must be after GPU code objects are loaded (which
+        # happens during hipMalloc) so the GPU target has been created.
         self.build_and_launch(program)
         source = "hello_world.hip"
-        breakpoint_line = line_number(source, "// CPU BREAKPOINT - BEFORE LAUNCH")
+        breakpoint_line = line_number(source, "// CPU BREAKPOINT - AFTER GPU INIT")
         self.set_source_breakpoints(source, [breakpoint_line])
         self.continue_to_next_stop()
 
@@ -78,12 +80,11 @@ class TestDAPAMDReverseRequest(lldbdap_testcase.DAPTestCaseBase):
         """
         self.build()
         log_file_path = self.getBuildArtifact("dap.txt")
-        # Enable detailed DAP logging to debug any issues
         program = self.getBuildArtifact("a.out")
         source = "hello_world.hip"
-        cpu_breakpoint_line = line_number(source, "// CPU BREAKPOINT")
+        cpu_breakpoint_line = line_number(source, "// CPU BREAKPOINT - AFTER GPU INIT")
         gpu_breakpoint_line = line_number(source, "// GPU BREAKPOINT")
-        # Launch DAP server
+        # Launch DAP server with connection mode (required for child sessions)
         _, connection = self.start_server(connection="listen://localhost:0")
 
         self.dap_server = dap_server.DebugAdapterServer(
@@ -94,9 +95,22 @@ class TestDAPAMDReverseRequest(lldbdap_testcase.DAPTestCaseBase):
             disconnectAutomatically=False,
         )
 
-        # Set CPU breakpoint and stop.
+        # Set CPU breakpoint.
         breakpoint_ids = self.set_source_breakpoints(source, [cpu_breakpoint_line])
-        self.continue_to_breakpoints(breakpoint_ids)
+
+        # Continue - with lazy GPU target creation, the process may first stop
+        # at the internal GPU loader breakpoint (_loader_debug_state) before
+        # reaching the user breakpoint. The internal breakpoint stop triggers
+        # the startDebugging reverse request which creates the GPU child session.
+        stopped_events = self.continue_to_next_stop()
+        body = stopped_events[0].get("body", {}) if stopped_events else {}
+        hit_bp_ids = body.get("hitBreakpointIds", [])
+
+        # If we stopped at an internal breakpoint (negative ID), continue
+        # to the user breakpoint.
+        if not any(str(bp_id) in breakpoint_ids for bp_id in hit_bp_ids):
+            self.continue_to_breakpoints(breakpoint_ids)
+
         # We should have a GPU child session automatically spawned now
         self.assertEqual(
             len(self.dap_server.get_child_sessions()), 1, "Expected 1 child GPU session"

--- a/lldb/test/API/tools/lldb-dap/gpu/amd/hello_world.hip
+++ b/lldb/test/API/tools/lldb-dap/gpu/amd/hello_world.hip
@@ -28,6 +28,7 @@ int main() {
     HIP_CHECK(hipMalloc(&device_data, n * sizeof(int)));
     // Copy data to device
     HIP_CHECK(hipMemcpy(device_data, host_data, n * sizeof(int), hipMemcpyHostToDevice));
+    printf("GPU initialized\n"); // CPU BREAKPOINT - AFTER GPU INIT
     // Launch kernel (single block, 4 threads)
     add_one<<<1, n>>>(device_data);
     // Check for kernel launch errors

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -717,8 +717,10 @@ LLDBServerPluginAMDGPU::BreakpointWasHit(GPUPluginBreakpointHitArgs &args) {
       } else {
         // Create new connection on demand first time there are new GPU modules
         // detected.
-        if (!m_is_connected && !m_is_listening)
+        if (!m_is_connected && !m_is_listening) {
           response.actions.connect_info = CreateConnection();
+          response.actions.session_name = GetSessionName();
+        }
         response.actions.load_libraries = true;
         response.auto_resume_native = false;
       }


### PR DESCRIPTION
## Summary
Due to recent change to lazily create GPU target until GPU modules loaded (https://github.com/clayborg/llvm-project/pull/83), a lot of timing are changed. GPU DAP reverse request tests fail under ninja's parallel test runner due to three issues: (1) the lazy GPU target creation path in `BreakpointWasHit` was missing the session name when creating the connection, causing the test to fail validating the reverse request structure; (2) the `startDebugging` handler crashed in stdio mode because it tried to create child sessions over a nonexistent network connection; and (3) the recv thread was not marked as daemon, causing the test process to hang on exit when a test failed mid-execution.

Additionally, the test breakpoint was moved after GPU initialization (`hipMalloc`) to ensure GPU code objects are loaded before the test inspects them, and the test now handles the internal loader breakpoint stop that can occur with lazy GPU target creation.

## Test plan
```
~/clayborg/llvm-project/build/Debug$ ./bin/llvm-lit -av /home/jeffreytan/clayborg/llvm-project/lldb/test/API/tools/lldb-dap/gpu/amd/TestDAP_gpu_reverse_request.py
llvm-lit: /home/jeffreytan/clayborg/llvm-project/lldb/test/API/lit.cfg.py:127: note: Deleting module cache at /home/jeffreytan/clayborg/llvm-project/build/Debug/lldb-test-build.noindex/module-cache-lldb/lldb-api.
llvm-lit: /home/jeffreytan/clayborg/llvm-project/lldb/test/API/lit.cfg.py:127: note: Deleting module cache at /home/jeffreytan/clayborg/llvm-project/build/Debug/lldb-test-build.noindex/module-cache-clang/lldb-api.
-- Testing: 1 tests, 1 workers --
PASS: lldb-api :: tools/lldb-dap/gpu/amd/TestDAP_gpu_reverse_request.py (1 of 1)

Testing Time: 11.69s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```