### PR TITLE
[lldb] Fix reverse-execution and qSupported ninja test regressions

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbreverse.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbreverse.py
@@ -100,9 +100,15 @@ class ReverseTestBase(GDBProxyTestBase):
         if self.is_command(packet, "qSupported", ":"):
             # Disable multiprocess support in the server and in LLDB
             # since Mac debugserver doesn't support it and we want lldb-server to
-            # be consistent with that
+            # be consistent with that.
+            # Also strip binary-upload features since the proxy suppresses
+            # binary 'x' packet reads (results starting with "O" can be
+            # mistaken for output packets by the test server code).
             reply = self.pass_through(packet.replace(";multiprocess", ""))
-            return reply.replace(";multiprocess", "") + ";ReverseStep+;ReverseContinue+"
+            reply = reply.replace(";multiprocess", "")
+            reply = reply.replace(";binary-upload+", "")
+            reply = reply.replace(";binary-upload-bare+", "")
+            return reply + ";ReverseStep+;ReverseContinue+"
         if packet == "c" or packet == "s":
             packet = "vCont;" + packet
         elif (
@@ -230,6 +236,7 @@ class ReverseTestBase(GDBProxyTestBase):
                     "mecount",
                     "medata",
                     "memory",
+                    "stop_id",
                 ]:
                     continue
                 raise ValueError(f"Unknown stop key '{key}' in {reply}")

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -932,6 +932,10 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
         "SupportedWatchpointTypes",
         "SupportedCompressions",
         "MultiMemRead",
+        "binary-upload-bare",
+        "gpu-plugins",
+        "lldb-settings",
+        "address-spaces",
     ]
 
     def parse_qSupported_response(self, context):

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -1175,7 +1175,8 @@ void GDBRemoteCommunicationServerLLGS::HandleInferiorState_Exited(
     // Terminate the main loop only if vKill has not been used.
     // When running in non-stop mode, wait for the vStopped to clear
     // the notification queue.
-    if (m_debugged_processes.empty() && !m_non_stop && !vkilled) {
+    if (m_debugged_processes.empty() && !m_non_stop && !vkilled &&
+        !m_plugin_instance) {
       // Close the pipe to the inferior terminal i/o if we launched it and set
       // one up.
       MaybeCloseInferiorTerminalConnection();

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1930,9 +1930,10 @@ size_t Process::ReadMemory(const AddressSpec &addr_spec, void *buf,
     llvm::Expected<lldb::addr_t> load_addr = 
         addr_spec.ResolveAddressInDefaultAddressSpace(*this);
     if (load_addr) {
-      // We were able to resolve the address to an address in the default 
-      // address space. Just call our standard read memory method.
-      return DoReadMemory(*load_addr, buf, size, error);
+      // We were able to resolve the address to an address in the default
+      // address space. Just call our standard read memory method which goes
+      // through memory caching and ABI address fixing.
+      return ReadMemory(*load_addr, buf, size, error);
     }
     error = Status::FromError(load_addr.takeError());
     return 0;


### PR DESCRIPTION
## Summary
Several LLDB API tests started failing under ninja after Greg's `d188432bdec7` change taught LLGS to advertise newer qSupported features, including `binary-upload-bare+`, `gpu-plugins+`, `lldb-settings+`, and `address-spaces+`.

That newer capability reply exposed two gaps in the existing test infrastructure. The reverse execution proxy in `lldbreverse.py` is not a transparent binary-safe proxy, so once LLDB sees `binary-upload-bare+` it can switch to LLDB-style bare binary `x` packet reads that the proxy may misclassify as console output packets. The gdb-remote qSupported parser in the server test harness was also still limited to the older feature set and would reject the newer reply fields.

At the same time, the reverse execution tests were relying on the default address-space read path, but `Process::ReadMemory(const AddressSpec &)` was calling directly into `DoReadMemory()` and bypassing the normal caching and ABI address-fixing logic that the rest of LLDB uses. LLGS could also tear down too early when a plugin-backed process exited, which made the fork/non-stop server tests unstable.

This change updates the reverse test proxy to hide the binary upload capabilities it cannot safely forward, accepts the newer qSupported and stop reply fields in the test harness, routes default-address-space reads through the regular process memory read path, and keeps LLGS alive while a plugin- backed debug session is still active.

Compared against `llvm-server-plugins`, this fixes the previously failing ninja tests:
- `lldb-api :: commands/process/reverse-continue/TestReverseContinue.py`
- `lldb-api :: functionalities/reverse-execution/TestReverseContinueBreakpoints.py`
- `lldb-api :: functionalities/reverse-execution/TestReverseContinueWatchpoints.py`
- `lldb-api :: tools/lldb-server/TestGdbRemoteAuxvSupport.py`
- `lldb-api :: tools/lldb-server/TestGdbRemoteForkNonStop.py`
- `lldb-api :: tools/lldb-server/TestGdbRemoteForkResume.py`
- `lldb-api :: tools/lldb-server/TestNonStop.py`
- `lldb-api :: tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.py`
- `lldb-api :: tools/lldb-server/qSupported/TestGdbRemote_qSupported.py`
- `lldb-api :: tools/lldb-server/TestGdbRemoteFork.py`
- `lldb-api :: tools/lldb-dap/attach/TestDAP_attach.py`
- `lldb-api :: tools/lldb-dap/gpu/amd/TestDAP_gpu_reverse_request.py`

It does not address the separate Module.cpp regressions or the `TestCppGlobalOperators.py` failure.

## Test plan
- `ninja -C build/Debug lldb lldb-server lldb-dap && ./build/Debug/bin/llvm-lit -av lldb/test/API/tools/lldb-server/TestGdbRemoteAuxvSupport.py lldb/test/API/tools/lldb-server/TestGdbRemoteForkNonStop.py lldb/test/API/tools/lldb-server/TestGdbRemoteForkResume.py lldb/test/API/tools/lldb-server/TestNonStop.py lldb/test/API/tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.py lldb/test/API/tools/lldb-server/qSupported/TestGdbRemote_qSupported.py lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py lldb/test/API/tools/lldb-dap/gpu/amd/TestDAP_gpu_reverse_request.py lldb/test/API/tools/lldb-server/TestGdbRemoteFork.py lldb/test/API/commands/process/reverse-continue/TestReverseContinue.py lldb/test/API/functionalities/module_cache/universal/TestModuleCacheUniversal.py lldb/test/API/functionalities/reverse-execution/TestReverseContinueBreakpoints.py lldb/test/API/functionalities/reverse-execution/TestReverseContinueWatchpoints.py lldb/test/API/lang/cpp/global_operators/TestCppGlobalOperators.py lldb/test/API/python_api/sbmodule/TestSBModule.py` Result on `llvm-server-plugins`: 12 regressions from the list above reproduce, while `TestModuleCacheUniversal.py`, `TestSBModule.py`, and `TestCppGlobalOperators.py` remain separate failures. Result on this branch: the 12 tests listed above pass; the three unrelated failures remain.
- `ninja -C build/Debug lldb lldb-server lldb-dap && ./build/Debug/bin/llvm-lit -av /home/jeffreytan/clayborg/llvm-project/lldb/test/API/gpu/amd/`