### PR TITLE
Query GPU architecture from agent instead of hardcoding gfx942

### DIFF
--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -222,12 +222,29 @@ Status LLDBServerPluginAMDGPU::AttachAmdDbgApi() {
                                       AMD_DBGAPI_STATUS_ERROR);
   }
 
-  // TODO: read the architecture from the attached agent.
+  // Query the architecture from the first attached GPU agent.
   amd_dbgapi_architecture_id_t architecture_id;
-  const uint32_t elf_amdgpu_machine = 0x04C;
-  status = amd_dbgapi_get_architecture(elf_amdgpu_machine, &architecture_id);
+  size_t agent_count = 0;
+  amd_dbgapi_agent_id_t *agents = nullptr;
+  status = amd_dbgapi_process_agent_list(m_gpu_pid, &agent_count, &agents,
+                                         nullptr);
+  if (status != AMD_DBGAPI_STATUS_SUCCESS || agent_count == 0) {
+    if (agents)
+      s_dbgapi_callbacks.deallocate_memory(agents);
+    return HandleAmdDbgApiAttachError(
+        agent_count == 0 ? "No GPU agents found"
+                         : "Failed to enumerate GPU agents",
+        status == AMD_DBGAPI_STATUS_SUCCESS ? AMD_DBGAPI_STATUS_ERROR
+                                            : status);
+  }
+
+  status = amd_dbgapi_agent_get_info(
+      agents[0], AMD_DBGAPI_AGENT_INFO_ARCHITECTURE,
+      sizeof(architecture_id), &architecture_id);
+  s_dbgapi_callbacks.deallocate_memory(agents);
   if (status != AMD_DBGAPI_STATUS_SUCCESS) {
-    return HandleAmdDbgApiAttachError("Failed to get architecture", status);
+    return HandleAmdDbgApiAttachError("Failed to get agent architecture",
+                                      status);
   }
   m_architecture_id = architecture_id;
 


### PR DESCRIPTION
Replace hardcoded ELF machine type 0x04C (gfx942) with a runtime query to the actual GPU agent via amd_dbgapi_agent_get_info. This fixes GPU debugging on MI350X (gfx950) where the hardcoded value caused an architecture mismatch resulting in "lost connection" errors.

Before (on MI350X): `arch=amdgcn-amd-amdhsa--gfx942` → lost connection
```
(lldb) target create "/tmp/a.out"
Current executable set to '/tmp/a.out' (x86_64).
(lldb) b /CPU BREAKPOINT - BEFORE LAUNCH/
Breakpoint 1: where = a.out`main + 42 at hello_world.hip:83:3, address = 0x000000000020b6ca
(lldb) run
Process 3739456 launched: '/tmp/a.out' (x86_64)
Process 3739456 stopped
* thread #1, name = 'a.out', stop reason = breakpoint 1.1
    frame #0: 0x000000000020b6ca a.out`main at hello_world.hip:83:3
   80  	  // Allocate host vectors
   81  	  const size_t size = strlen("Hello, world!");
   82  	  std::string h_str(size, '?');
-> 83  	  printf("%s\n", h_str.c_str()); // CPU BREAKPOINT - BEFORE LAUNCH
   84
   85  	  // Allocate device memory for the output data
   86  	  char *d_str;
(lldb) target list
Current targets:
* target #0: /tmp/a.out ( arch=x86_64-unknown-linux-gnu, platform=host, pid=3739456, state=stopped )
(lldb) c
Process 3739456 resuming
?????????????
Copying data to device...
Process 1 stopped
* thread #1, name = 'AMD Native Shadow Thread', stop reason = signal SIGTRAP
    frame #0: 0x0000000000000000
Target 0: (a.out) stopped.
(lldb) target select 1
Current targets:
  target #0: /tmp/a.out ( arch=x86_64-unknown-linux-gnu, platform=host, pid=3739456, state=stopped )
* target #1: amd_memory_kernel[0xdf4b00, 0xdfca88) ( arch=amdgcn-amd-amdhsa--gfx942, platform=host, pid=1, state=stopped )
(lldb) b hello_world.hip:73
Breakpoint 1: no locations (pending).
WARNING:  Unable to resolve breakpoint to any actual locations.
(lldb) c
Process 1 resuming
(lldb) target select 0
Current targets:
* target #0: /tmp/a.out ( arch=x86_64-unknown-linux-gnu, platform=host, pid=3739456, state=stopped )
  target #1: amd_memory_kernel[0xdf4b00, 0xdfca88) ( arch=amdgcn-amd-amdhsa--gfx942, platform=host, pid=1, state=running )
(lldb) c
Process 3739456 resuming
Launching kernel...
1 location added to breakpoint 1
Copying data to host...
Process 1 exited with status = -1 (0xffffffff) lost connection
Process 3739456 exited with status = -1 (0xffffffff) lost connection
(lldb) target list
Current targets:
* target #0: /tmp/a.out ( arch=x86_64-unknown-linux-gnu, platform=host, pid=3739456, state=exited )
  target #1: amd_memory_kernel[0xdf4b00, 0xdfca88) ( arch=amdgcn-amd-amdhsa--gfx942, platform=host, pid=1, state=exited )
(lldb) target select 1
Current targets:
  target #0: /tmp/a.out ( arch=x86_64-unknown-linux-gnu, platform=host, pid=3739456, state=exited )
* target #1: amd_memory_kernel[0xdf4b00, 0xdfca88) ( arch=amdgcn-amd-amdhsa--gfx942, platform=host, pid=1, state=exited )
(lldb) f
error: Command requires a process which is currently stopped.
(lldb)
```


After (on MI350X): `arch=amdgcn-amd-amdhsa--gfx950` → stops at helloworld_kernel line 74
```
(lldb) target create "/tmp/a.out"
Current executable set to '/tmp/a.out' (x86_64).
(lldb) b /CPU BREAKPOINT - BEFORE LAUNCH/
Breakpoint 1: where = a.out`main + 42 at hello_world.hip:83:3, address = 0x000000000020b6ea
(lldb) run
Process 3087657 launched: '/tmp/a.out' (x86_64)
Process 3087657 stopped
* thread #1, name = 'a.out', stop reason = breakpoint 1.1
    frame #0: 0x000000000020b6ea a.out`main at hello_world.hip:83:3
   80  	  // Allocate host vectors
   81  	  const size_t size = strlen("Hello, world!");
   82  	  std::string h_str(size, '?');
-> 83  	  printf("%s\n", h_str.c_str()); // CPU BREAKPOINT - BEFORE LAUNCH
   84
   85  	  // Allocate device memory for the output data
   86  	  char *d_str;
(lldb) c
Process 3087657 resuming
?????????????
Copying data to device...
Process 1 stopped
* thread #1, name = 'AMD Native Shadow Thread', stop reason = signal SIGTRAP
    frame #0: 0x0000000000000000
error: memory read failed for 0x0
Target 0: (a.out) stopped.
(lldb) target select 1
Current targets:
  target #0: /tmp/a.out ( arch=x86_64-unknown-linux-gnu, platform=host, pid=3087657, state=stopped )
* target #1: amd_memory_kernel[0x1765870, 0x176d7f8) ( arch=amdgcn-amd-amdhsa--gfx950, platform=host, pid=1, state=stopped )
(lldb) b hello_world.hip:73
Breakpoint 1: no locations (pending).
WARNING:  Unable to resolve breakpoint to any actual locations.
(lldb) c
Process 1 resuming
(lldb) target select 0
Current targets:
* target #0: /tmp/a.out ( arch=x86_64-unknown-linux-gnu, platform=host, pid=3087657, state=stopped )
  target #1: amd_memory_kernel[0x1765870, 0x176d7f8) ( arch=amdgcn-amd-amdhsa--gfx950, platform=host, pid=1, state=running )
(lldb) c
Process 3087657 resuming
Launching kernel...
1 location added to breakpoint 1
Copying data to host...
Target 1: (amd_memory_kernel[0x1765870, 0x176d7f8)) stopped.
(lldb) target select 1
Current targets:
  target #0: /tmp/a.out ( arch=x86_64-unknown-linux-gnu, platform=host, pid=3087657, state=running )
* target #1: amd_memory_kernel[0x1765870, 0x176d7f8) ( arch=amdgcn-amd-amdhsa--gfx950, platform=host, pid=1, state=stopped )
(lldb) f
frame #0: 0x00007ffff6431b80 a.out`helloworld_kernel(str=<unavailable>, size=<unavailable>) at hello_world.hip:74:7
   71  	    case 12: c = '!'; break;
   72  	  }
   73
-> 74  	  if (idx < size) { // GPU BREAKPOINT
   75  	    str[idx] = c;
   76  	  }
   77  	}
(lldb)
```