### PR TITLE
[amdgpu-core] Query GPU architecture from agent

### DIFF
--- a/lldb/include/lldb/Utility/AmdGpuCoreUtils.h
+++ b/lldb/include/lldb/Utility/AmdGpuCoreUtils.h
@@ -11,6 +11,8 @@
 
 #include "lldb/Utility/GPUGDBRemotePackets.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include <amd-dbgapi/amd-dbgapi.h>
 #include <optional>
 #include <string>
 
@@ -55,6 +57,16 @@ struct AmdGpuCodeObject {
 ///     parsed, or std::nullopt if parsing failed.
 std::optional<GPUDynamicLoaderLibraryInfo>
 ParseLibraryInfo(const AmdGpuCodeObject &code_object);
+
+/// Query the GPU architecture id from the first attached agent of an AMD
+/// dbgapi process. On success returns the architecture id; on failure returns
+/// an llvm::Error whose message describes the failure (and includes the
+/// underlying amd_dbgapi status code where applicable).
+///
+/// \param[in] gpu_pid
+///     The AMD dbgapi process id obtained from amd_dbgapi_process_attach.
+llvm::Expected<amd_dbgapi_architecture_id_t>
+QueryAmdGpuArchitectureFromFirstAgent(amd_dbgapi_process_id_t gpu_pid);
 
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
@@ -334,28 +334,13 @@ bool ProcessAmdGpuCore::initRocm() {
     return false;
   }
 
-  amd_dbgapi_architecture_id_t architecture_id;
-  size_t agent_count = 0;
-  amd_dbgapi_agent_id_t *agents = nullptr;
-  status = amd_dbgapi_process_agent_list(m_gpu_pid, &agent_count, &agents,
-                                         nullptr);
-  if (status != AMD_DBGAPI_STATUS_SUCCESS || agent_count == 0) {
-    if (agents)
-      free(agents);
-    LLDB_LOGF(GetLog(LLDBLog::Process),
-              agent_count == 0 ? "No GPU agents found"
-                               : "Failed to enumerate GPU agents");
+  llvm::Expected<amd_dbgapi_architecture_id_t> arch_or_err =
+      QueryAmdGpuArchitectureFromFirstAgent(m_gpu_pid);
+  if (!arch_or_err) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Process), arch_or_err.takeError(), "{0}");
     return false;
   }
-  status = amd_dbgapi_agent_get_info(agents[0],
-                                     AMD_DBGAPI_AGENT_INFO_ARCHITECTURE,
-                                     sizeof(architecture_id), &architecture_id);
-  free(agents);
-  if (status != AMD_DBGAPI_STATUS_SUCCESS) {
-    LLDB_LOGF(GetLog(LLDBLog::Process), "Failed to get agent architecture");
-    return false;
-  }
-  m_architecture_id = architecture_id;
+  m_architecture_id = *arch_or_err;
 
   m_address_spaces.push_back({"generic", (uint64_t)DW_ASPACE_AMDGPU::generic,
                               /*is_thread_specific=*/true});

--- a/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
@@ -335,11 +335,24 @@ bool ProcessAmdGpuCore::initRocm() {
   }
 
   amd_dbgapi_architecture_id_t architecture_id;
-  // TODO: do not hardcode the device id
-  status = amd_dbgapi_get_architecture(0x04C, &architecture_id);
+  size_t agent_count = 0;
+  amd_dbgapi_agent_id_t *agents = nullptr;
+  status = amd_dbgapi_process_agent_list(m_gpu_pid, &agent_count, &agents,
+                                         nullptr);
+  if (status != AMD_DBGAPI_STATUS_SUCCESS || agent_count == 0) {
+    if (agents)
+      free(agents);
+    LLDB_LOGF(GetLog(LLDBLog::Process),
+              agent_count == 0 ? "No GPU agents found"
+                               : "Failed to enumerate GPU agents");
+    return false;
+  }
+  status = amd_dbgapi_agent_get_info(agents[0],
+                                     AMD_DBGAPI_AGENT_INFO_ARCHITECTURE,
+                                     sizeof(architecture_id), &architecture_id);
+  free(agents);
   if (status != AMD_DBGAPI_STATUS_SUCCESS) {
-    // Handle error
-    LLDB_LOGF(GetLog(LLDBLog::Process), "amd_dbgapi_get_architecture failed");
+    LLDB_LOGF(GetLog(LLDBLog::Process), "Failed to get agent architecture");
     return false;
   }
   m_architecture_id = architecture_id;

--- a/lldb/source/Utility/AmdGpuCoreUtils.cpp
+++ b/lldb/source/Utility/AmdGpuCoreUtils.cpp
@@ -77,3 +77,33 @@ lldb_private::ParseLibraryInfo(const AmdGpuCodeObject &code_object) {
 
   return lib_info;
 }
+
+llvm::Expected<amd_dbgapi_architecture_id_t>
+lldb_private::QueryAmdGpuArchitectureFromFirstAgent(
+    amd_dbgapi_process_id_t gpu_pid) {
+  size_t agent_count = 0;
+  amd_dbgapi_agent_id_t *agents = nullptr;
+  amd_dbgapi_status_t status =
+      amd_dbgapi_process_agent_list(gpu_pid, &agent_count, &agents, nullptr);
+  if (status != AMD_DBGAPI_STATUS_SUCCESS || agent_count == 0) {
+    if (agents)
+      free(agents);
+    if (agent_count == 0)
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "No GPU agents found");
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "Failed to enumerate GPU agents (status=%d)",
+                                   status);
+  }
+
+  amd_dbgapi_architecture_id_t architecture_id;
+  status = amd_dbgapi_agent_get_info(agents[0],
+                                     AMD_DBGAPI_AGENT_INFO_ARCHITECTURE,
+                                     sizeof(architecture_id), &architecture_id);
+  free(agents);
+  if (status != AMD_DBGAPI_STATUS_SUCCESS)
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "Failed to get agent architecture (status=%d)", status);
+  return architecture_id;
+}

--- a/lldb/source/Utility/CMakeLists.txt
+++ b/lldb/source/Utility/CMakeLists.txt
@@ -23,6 +23,13 @@ if (NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB )
     list(APPEND LLDB_SYSTEM_LIBS atomic)
 endif()
 
+if(LLDB_ENABLE_AMDGPU_PLUGIN)
+  set(amd-dbgapi_DIR "${ROCM_PATH}/lib/cmake/amd-dbgapi"
+      CACHE PATH "Path to amd-dbgapi cmake config" FORCE)
+  find_package(amd-dbgapi REQUIRED CONFIG)
+  list(APPEND LLDB_SYSTEM_LIBS amd-dbgapi)
+endif()
+
 add_lldb_library(lldbUtility NO_INTERNAL_DEPENDENCIES
   AddressableBits.cpp
   AddressSpace.cpp

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -14,6 +14,7 @@
 #include "ThreadAMDGPU.h"
 #include "lldb/Host/common/TCPSocket.h"
 #include "lldb/Host/posix/ConnectionFileDescriptorPosix.h"
+#include "lldb/Utility/AmdGpuCoreUtils.h"
 #include "lldb/Utility/GPUGDBRemotePackets.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Status.h"
@@ -223,30 +224,14 @@ Status LLDBServerPluginAMDGPU::AttachAmdDbgApi() {
   }
 
   // Query the architecture from the first attached GPU agent.
-  amd_dbgapi_architecture_id_t architecture_id;
-  size_t agent_count = 0;
-  amd_dbgapi_agent_id_t *agents = nullptr;
-  status = amd_dbgapi_process_agent_list(m_gpu_pid, &agent_count, &agents,
-                                         nullptr);
-  if (status != AMD_DBGAPI_STATUS_SUCCESS || agent_count == 0) {
-    if (agents)
-      s_dbgapi_callbacks.deallocate_memory(agents);
-    return HandleAmdDbgApiAttachError(
-        agent_count == 0 ? "No GPU agents found"
-                         : "Failed to enumerate GPU agents",
-        status == AMD_DBGAPI_STATUS_SUCCESS ? AMD_DBGAPI_STATUS_ERROR
-                                            : status);
+  llvm::Expected<amd_dbgapi_architecture_id_t> arch_or_err =
+      QueryAmdGpuArchitectureFromFirstAgent(m_gpu_pid);
+  if (!arch_or_err) {
+    std::string err_msg = llvm::toString(arch_or_err.takeError());
+    return HandleAmdDbgApiAttachError(err_msg.c_str(),
+                                      AMD_DBGAPI_STATUS_ERROR);
   }
-
-  status = amd_dbgapi_agent_get_info(
-      agents[0], AMD_DBGAPI_AGENT_INFO_ARCHITECTURE,
-      sizeof(architecture_id), &architecture_id);
-  s_dbgapi_callbacks.deallocate_memory(agents);
-  if (status != AMD_DBGAPI_STATUS_SUCCESS) {
-    return HandleAmdDbgApiAttachError("Failed to get agent architecture",
-                                      status);
-  }
-  m_architecture_id = architecture_id;
+  m_architecture_id = *arch_or_err;
 
   // The process from LLDB’s PoV is the entire portion of logical GPU bound to
   // the CPU host process. It does not represent a real process on the GPU. The


### PR DESCRIPTION
Follow-up to [PR#96](https://github.com/clayborg/llvm-project/pull/96): this PR applies the same fix to coredump debugging. Replaces the hardcoded 0x04C (gfx942) device ID with a dynamic query using amd_dbgapi_process_agent_list + amd_dbgapi_agent_get_info. 

Before (on MI350X/gfx950): 
```
(lldb) target list
Current targets:
  target #0: ... ( arch=x86_64-*-linux, platform=host, pid=694495, state=stopped )
* target #1: ... ( arch=amdgcn-amd-amdhsa--gfx942, platform=host, state=stopped )
```

After (on MI350X/gfx950): 
```
(lldb) target list
Current targets:
  target #0: ... ( arch=x86_64-*-linux, platform=host, pid=694495, state=stopped )
* target #1: ... ( arch=amdgcn-amd-amdhsa--gfx950, platform=host, state=stopped )
```

