### PR TITLE
[lldb] Fix ModuleSpec matching for container-backed modules related tests

### DIFF
--- a/lldb/include/lldb/Core/ModuleSpec.h
+++ b/lldb/include/lldb/Core/ModuleSpec.h
@@ -116,6 +116,40 @@ public:
 
   void SetObjectSize(uint64_t object_size) { m_object_size = object_size; }
 
+  /// Returns true when this spec carries explicit byte bounds for a subobject
+  /// inside the backing file or supplied data buffer.
+  bool HasObjectFileBounds() const {
+    if (m_object_offset != 0)
+      return true;
+    if (m_object_size == 0)
+      return false;
+    if (m_data)
+      return m_object_size != m_data->GetByteSize();
+    if (!m_file)
+      return false;
+    const uint64_t file_size = FileSystem::Instance().GetByteSize(m_file);
+    return file_size != 0 && m_object_size != file_size;
+  }
+
+  /// Returns true when this spec identifies a subobject inside the backing
+  /// file, so object offset and size should participate in matching.
+  bool HasObjectFileSlice() const {
+    return m_object_name || HasObjectFileBounds();
+  }
+
+  /// Checks whether this spec's requested object offset and size match a
+  /// candidate object range.
+  bool MatchesObjectFileSlice(uint64_t object_offset,
+                              uint64_t object_size) const {
+    if (!HasObjectFileSlice())
+      return true;
+    if (GetObjectOffset() != object_offset)
+      return false;
+    if (GetObjectSize() != 0 && GetObjectSize() != object_size)
+      return false;
+    return true;
+  }
+
   llvm::sys::TimePoint<> &GetObjectModificationTime() {
     return m_object_mod_time;
   }
@@ -245,6 +279,9 @@ public:
         match_module_spec.GetObjectName() != GetObjectName())
       return false;
     if (!FileSpec::Match(match_module_spec.GetFileSpec(), GetFileSpec()))
+      return false;
+    if (!match_module_spec.MatchesObjectFileSlice(GetObjectOffset(),
+                                                  GetObjectSize()))
       return false;
     if (GetPlatformFileSpec() &&
         !FileSpec::Match(match_module_spec.GetPlatformFileSpec(),

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -150,17 +150,23 @@ Module::Module(const ModuleSpec &module_spec)
               module_spec.GetObjectName().IsEmpty() ? "" : ")");
 
   auto data_sp = module_spec.GetData();
+  lldb::offset_t file_size = 0;
+  if (data_sp)
+    file_size = data_sp->GetByteSize();
 
-  // First extract all module specifications from the file using the local file
-  // path. If there are no specifications, then don't fill anything in
+  // Slice-backed callers already describe the exact subobject they want. Plain
+  // file lookups still need whole-file enumeration so container plugins can
+  // contribute every member or slice before we pick the matching spec.
   ModuleSpecList modules_specs;
-
-  if (ObjectFile::GetModuleSpecifications(
-          module_spec.GetFileSpec(), 
-          module_spec.GetObjectOffset(), 
-          module_spec.GetObjectSize(), 
-          modules_specs, 
-          data_sp) == 0)
+  const bool use_explicit_bounds =
+      data_sp && module_spec.HasObjectFileBounds();
+  const auto module_offset =
+      use_explicit_bounds ? module_spec.GetObjectOffset() : 0;
+  const auto module_size =
+      use_explicit_bounds ? module_spec.GetObjectSize() : file_size;
+  if (ObjectFile::GetModuleSpecifications(module_spec.GetFileSpec(),
+                                          module_offset, module_size,
+                                          modules_specs, data_sp) == 0)
     return;
 
   // Now make sure that one of the module specifications matches what we just
@@ -1199,10 +1205,15 @@ ObjectFile *Module::GetObjectFile() {
         // FindPlugin will modify its data_sp argument. Do not let it
         // modify our m_data_sp member.
         auto data_sp = m_data_sp;
+        // Memory-backed slices already supply the exact subobject bytes. Plain
+        // file-backed container members still reopen through the rest of the
+        // backing file so the object plugin can recover the final bounds.
+        const lldb::offset_t object_size =
+            (m_data_sp && m_object_size) ? m_object_size
+                                         : file_size - m_object_offset;
         m_objfile_sp = ObjectFile::FindPlugin(
-            shared_from_this(), &m_file, m_object_offset,
-            m_object_size ? m_object_size : file_size - m_object_offset, 
-            data_sp, data_offset);
+            shared_from_this(), &m_file, m_object_offset, object_size, data_sp,
+            data_offset);
         if (m_objfile_sp) {
           // Once we get the object file, update our module with the object
           // file's architecture since it might differ in vendor/os if some
@@ -1524,7 +1535,7 @@ bool Module::MatchesModuleSpec(const ModuleSpec &module_ref) {
   if (!FileSpec::Match(platform_file_spec, GetPlatformFileSpec()))
     return false;
 
-  if (m_object_offset != module_ref.GetObjectOffset())
+  if (!module_ref.MatchesObjectFileSlice(m_object_offset, m_object_size))
     return false;
 
   const ArchSpec &arch = module_ref.GetArchitecture();


### PR DESCRIPTION
## Summary

Commit 5983f642c224 ("Make module loading work within a file") changed Module::Module to call GetModuleSpecifications only for the requested subrange. This preserved AMD GPU code object loading on this branch, but it also prevented LLDB from enumerating all members/slices within a container file. As a result:

- SBModule could no longer correctly resolve archive members.
- The universal module cache test stopped finding the expected slice.

This change restores whole-file container discovery for file-backed lookups while preserving explicit slice bounds for GPU modules whose object bytes are already supplied in memory.

Specifically:

- File-backed lookups once again enumerate the full container so archive members and universal binary slices can be rediscovered by the container plugin.
- Slice-backed/in-memory GPU modules continue to honor the provided object offset and size, ensuring the intended embedded AMD code object is selected.
- Object-slice matching behavior is centralized in ModuleSpec to keep matching rules consistent.

This restores the previous behavior for archive and universal container handling while maintaining support for AMD code object loading on this branch.

## Test Plan

- build/Debug/bin/llvm-lit -av lldb/test/API/python_api/sbmodule/TestSBModule.py
- build/Debug/bin/llvm-lit -av lldb/test/API/functionalities/module_cache/universal/TestModuleCacheUniversal.py
- build/Debug/bin/llvm-lit -av /home/jeffreytan/clayborg/llvm-project/lldb/test/API/gpu/amd/