### PR TITLE
[lldb] Load AMDGPU code object symbols by build ID

### DIFF
--- a/lldb/include/lldb/Target/AmdGpuSymbolLoader.h
+++ b/lldb/include/lldb/Target/AmdGpuSymbolLoader.h
@@ -1,0 +1,35 @@
+//===-- AmdGpuSymbolLoader.h -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TARGET_AMDGPUSYMBOLLOADER_H
+#define LLDB_TARGET_AMDGPUSYMBOLLOADER_H
+
+#include "lldb/lldb-forward.h"
+
+namespace lldb_private {
+
+class Target;
+
+/// Attempt to attach separate debug info to an AMDGPU code-object module.
+///
+/// AMDGPU core files can create modules for code objects before their separate
+/// debug info has been attached. This helper resolves the module's UUID/build
+/// ID through LLDB's external symbol lookup path, attaches the resolved symbol
+/// file, creates its SymbolFile, and notifies the target.
+///
+/// Lookup follows LLDB's normal external-symbol order: the target platform's
+/// locate-module callback, registered symbol-locator plugins and debug-file
+/// search paths, and explicit symbol-locator download callbacks.
+///
+/// Returns true if a symbol file was found and loaded.
+bool LoadAmdGpuCodeObjectSymbols(Target &target,
+                                 const lldb::ModuleSP &module_sp);
+
+} // namespace lldb_private
+
+#endif // LLDB_TARGET_AMDGPUSYMBOLLOADER_H

--- a/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
@@ -14,6 +14,7 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Target/AmdGpuSymbolLoader.h"
 #include "lldb/Utility/AmdGpuAddressSpaces.h"
 #include "lldb/Utility/AmdGpuCoreUtils.h"
 #include "lldb/Utility/DataBufferHeap.h"
@@ -625,6 +626,7 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
           loaded_modules.AppendIfNeeded(module_sp);
         }
       }
+      LoadAmdGpuCodeObjectSymbols(target, module_sp);
     }
 
     s_dbgapi_callbacks.deallocate_memory(uri_bytes);

--- a/lldb/source/Target/AmdGpuSymbolLoader.cpp
+++ b/lldb/source/Target/AmdGpuSymbolLoader.cpp
@@ -1,0 +1,93 @@
+//===-- AmdGpuSymbolLoader.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Target/AmdGpuSymbolLoader.h"
+
+#include "lldb/Core/Module.h"
+#include "lldb/Core/ModuleList.h"
+#include "lldb/Core/ModuleSpec.h"
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Symbol/SymbolFile.h"
+#include "lldb/Target/Platform.h"
+#include "lldb/Target/Statistics.h"
+#include "lldb/Target/Target.h"
+#include "lldb/Utility/FileSpecList.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
+#include "lldb/Utility/Status.h"
+#include "lldb/Utility/StreamString.h"
+#include "lldb/Utility/UUID.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+bool lldb_private::LoadAmdGpuCodeObjectSymbols(Target &target,
+                                               const ModuleSP &module_sp) {
+  if (!module_sp || module_sp->GetSymbolFileFileSpec())
+    return false;
+
+  if (!ModuleList::GetGlobalModuleListProperties().GetEnableExternalLookup())
+    return false;
+
+  const UUID &uuid = module_sp->GetUUID();
+  if (!uuid.IsValid())
+    return false;
+
+  ModuleSpec module_spec(module_sp->GetFileSpec(), uuid);
+  module_spec.GetArchitecture() = module_sp->GetArchitecture();
+  module_spec.SetObjectOffset(module_sp->GetObjectOffset());
+  module_spec.SetObjectSize(module_sp->GetObjectSize());
+
+  FileSpec symbol_file_spec;
+  if (PlatformSP platform_sp = target.GetPlatform()) {
+    ModuleSP located_module_sp;
+    bool did_create = false;
+    platform_sp->CallLocateModuleCallbackIfSet(module_spec, located_module_sp,
+                                               symbol_file_spec, &did_create);
+    if (symbol_file_spec)
+      module_spec.GetSymbolFileSpec() = symbol_file_spec;
+  }
+
+  StatisticsMap symbol_locator_map;
+  if (!module_spec.GetSymbolFileSpec()) {
+    FileSpecList search_paths = Target::GetDefaultDebugFileSearchPaths();
+    module_spec.GetSymbolFileSpec() = PluginManager::LocateExecutableSymbolFile(
+        module_spec, search_paths, symbol_locator_map);
+    module_sp->GetSymbolLocatorStatistics().merge(symbol_locator_map);
+  }
+
+  Status error;
+  if (!module_spec.GetSymbolFileSpec()) {
+    PluginManager::DownloadObjectAndSymbolFile(module_spec, error,
+                                               /*force_lookup=*/true,
+                                               /*copy_executable=*/false);
+  }
+
+  const FileSpec &resolved_symbol_file_spec = module_spec.GetSymbolFileSpec();
+  if (!resolved_symbol_file_spec)
+    return false;
+
+  module_sp->SetSymbolFileFileSpec(resolved_symbol_file_spec);
+  SymbolFile *symbol_file = module_sp->GetSymbolFile(/*can_create=*/true);
+  if (!symbol_file) {
+    LLDB_LOG(GetLog(LLDBLog::Symbols),
+             "Failed to load AMDGPU code-object symbol file {0}",
+             resolved_symbol_file_spec);
+    return false;
+  }
+
+  ModuleList module_list;
+  module_list.Append(module_sp);
+  target.SymbolsDidLoad(module_list);
+
+  Status scripting_error;
+  StreamString scripting_feedback;
+  module_sp->LoadScriptingResourceInTarget(&target, scripting_error,
+                                           scripting_feedback);
+  return true;
+}

--- a/lldb/source/Target/CMakeLists.txt
+++ b/lldb/source/Target/CMakeLists.txt
@@ -9,6 +9,7 @@ lldb_tablegen(TargetPropertiesEnum.inc -gen-lldb-property-enum-defs
 # TODO: Add property `NO_PLUGIN_DEPENDENCIES` to lldbTarget
 add_lldb_library(lldbTarget
   ABI.cpp
+  AmdGpuSymbolLoader.cpp
   AssertFrameRecognizer.cpp
   DynamicRegisterInfo.cpp
   CoreFileMemoryRanges.cpp


### PR DESCRIPTION
## Summary

Load separate debug symbols for AMDGPU code-object modules in merged GPU core debugging.

  After ProcessAmdGpuCore creates a module for each GPU code object, this change reuses LLDB's existing symbol lookup flow:

  - use the module UUID when populated from the GNU build ID
  - call the platform locate-module callback if configured
  - fall back to generic SymbolLocator lookup/download hooks
  - attach the resolved symbol file to the GPU code-object module
  - notify the target that symbols were loaded

  This keeps ROCLLDB independent of any specific symbol server implementation.

  ## Testing

  - `ninja -C build-roclldb lldb`
  - Manual merged-core validation with a real AMDGPU core and separate GPU `.debug` file
  - Verified the GPU frame resolves from function-only output to source location after symbol loading

Manual validation on (MI350 / gfx950):

Built LLDB from this branch:

      ninja -C build-roclldb lldb

  Built a HIP test binary with a GPU code-object build ID.

  Extracted the embedded `.hip_fatbin`, unbundled the `gfx950` code object, and verified:

      Build ID: b0822178dc48c979837b162bb17c55cdc3efcd34

  Created a stripped test executable where the embedded `gfx950` code object keeps
  `.note.gnu.build-id` but has GPU DWARF stripped. Placed the full GPU debug file at:

      symbols/.build-id/b0/822178dc48c979837b162bb17c55cdc3efcd34.debug

  Generated a real GPU core using `rocgdb gcore` while stopped in the GPU kernel.

  Verified the negative case without the debug search path:

      target create --core <core> <stripped-executable>
      image lookup -a 0x7ffff5df7920

      Summary: stack_unwind_gfx950.stripped_gpu_debug`leaf_function(int, int*, int, int*, Point*)

  Loaded the stripped executable and generated core in this branch's LLDB with the
  debug search path configured before loading the core:

      settings set target.debug-file-search-paths <workdir>/symbols
      target create --core <core> <stripped-executable>
      image lookup -a 0x7ffff5df7920

  Verified that LLDB resolved source info for the GPU code-object module by build ID:

      Summary: stack_unwind_gfx950.stripped_gpu_debug`leaf_function(int, int*, int, int*, Point*) at stack_unwind_gfx950.hip:<line>

  Late opt-in by setting `target.debug-file-search-paths` after the core is already
  loaded was not expected to resolve symbols automatically; explicit
  `target symbols add <debug-file>` still works for that case.
