### PR TITLE
[LLDB][NVGPU] Stop reporting SIGTRAP on quiescent coredump lanes

### DIFF
--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
@@ -153,17 +153,18 @@ ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
                        lldb::SectionSP warp_section_sp,
                        lldb::SectionSP sm_section_sp, ObjectFileELF *core) {
   if (lane.exception != 0)
-    return StopAttribution{lane.exception, false};
+    return StopAttribution{lane.exception, false, ""};
 
   Log *log = GetLog(LLDBLog::Process);
   llvm::Expected<WarpEntry> warp_or =
       ReadAndDecode<WarpEntry>(warp_section_sp, core);
   if (!warp_or) {
-    LLDB_LOG_ERROR(log, warp_or.takeError(),
-                   "Failed to decode GPU warp data while attributing "
-                   "stop reason to lane {1}: {0}",
-                   lane_idx);
-    return std::nullopt;
+    std::string err =
+        llvm::formatv("failed to decode GPU warp data for lane {0}: {1}",
+                      lane_idx, llvm::toString(warp_or.takeError()))
+            .str();
+    LLDB_LOG(log, "{0}", err);
+    return StopAttribution{0, false, std::move(err)};
   }
 
   // The SDK has no `CUDBG_EXCEPTION_TRAP`; an inline trap surfaces as
@@ -173,20 +174,24 @@ ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
       warp_or->isWarpBroken && warp_or->IsLaneActive(lane_idx);
 
   uint32_t attributed_exception = 0;
+  std::string decode_error;
   if (warp_or->errorPCValid && warp_or->IsLaneActive(lane_idx)) {
     llvm::Expected<SMEntry> sm_or = ReadAndDecode<SMEntry>(sm_section_sp, core);
-    if (!sm_or)
-      LLDB_LOG_ERROR(log, sm_or.takeError(),
-                     "Failed to decode GPU SM data while attributing "
-                     "stop reason to lane {1}: {0}",
-                     lane_idx);
-    else
+    if (!sm_or) {
+      decode_error =
+          llvm::formatv("failed to decode GPU SM data for lane {0}: {1}",
+                        lane_idx, llvm::toString(sm_or.takeError()))
+              .str();
+      LLDB_LOG(log, "{0}", decode_error);
+    } else {
       attributed_exception = sm_or->exception;
+    }
   }
 
-  if (attributed_exception == 0 && !warp_broken_active)
+  if (attributed_exception == 0 && !warp_broken_active && decode_error.empty())
     return std::nullopt;
-  return StopAttribution{attributed_exception, warp_broken_active};
+  return StopAttribution{attributed_exception, warp_broken_active,
+                         std::move(decode_error)};
 }
 
 } // namespace lldb_private::nvgpu_core

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
@@ -148,16 +148,12 @@ std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane) {
                                  lane.threadIdxZ);
 }
 
-StopAttribution ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
-                                       lldb::SectionSP warp_section_sp,
-                                       lldb::SectionSP sm_section_sp,
-                                       ObjectFileELF *core) {
-  StopAttribution out;
-
-  if (lane.exception != 0) {
-    out.attributed_exception = lane.exception;
-    return out;
-  }
+std::optional<StopAttribution>
+ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
+                       lldb::SectionSP warp_section_sp,
+                       lldb::SectionSP sm_section_sp, ObjectFileELF *core) {
+  if (lane.exception != 0)
+    return StopAttribution{lane.exception, false};
 
   Log *log = GetLog(LLDBLog::Process);
   llvm::Expected<WarpEntry> warp_or =
@@ -167,28 +163,30 @@ StopAttribution ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
                    "Failed to decode GPU warp data while attributing "
                    "stop reason to lane {1}: {0}",
                    lane_idx);
-    return out;
+    return std::nullopt;
   }
 
   // The SDK has no `CUDBG_EXCEPTION_TRAP`; an inline trap surfaces as
   // `isWarpBroken`. Gate by active lane so unrelated lanes on the same
   // warp don't claim the trap.
-  if (warp_or->isWarpBroken && warp_or->IsLaneActive(lane_idx))
-    out.warp_broken_active = true;
+  const bool warp_broken_active =
+      warp_or->isWarpBroken && warp_or->IsLaneActive(lane_idx);
 
-  if (!warp_or->errorPCValid || !warp_or->IsLaneActive(lane_idx))
-    return out;
-
-  llvm::Expected<SMEntry> sm_or = ReadAndDecode<SMEntry>(sm_section_sp, core);
-  if (!sm_or) {
-    LLDB_LOG_ERROR(log, sm_or.takeError(),
-                   "Failed to decode GPU SM data while attributing "
-                   "stop reason to lane {1}: {0}",
-                   lane_idx);
-    return out;
+  uint32_t attributed_exception = 0;
+  if (warp_or->errorPCValid && warp_or->IsLaneActive(lane_idx)) {
+    llvm::Expected<SMEntry> sm_or = ReadAndDecode<SMEntry>(sm_section_sp, core);
+    if (!sm_or)
+      LLDB_LOG_ERROR(log, sm_or.takeError(),
+                     "Failed to decode GPU SM data while attributing "
+                     "stop reason to lane {1}: {0}",
+                     lane_idx);
+    else
+      attributed_exception = sm_or->exception;
   }
-  out.attributed_exception = sm_or->exception;
-  return out;
+
+  if (attributed_exception == 0 && !warp_broken_active)
+    return std::nullopt;
+  return StopAttribution{attributed_exception, warp_broken_active};
 }
 
 } // namespace lldb_private::nvgpu_core

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
@@ -154,9 +154,6 @@ StopAttribution ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
                                        ObjectFileELF *core) {
   StopAttribution out;
 
-  // A per-lane exception is definitive: a lane only carries an exception
-  // if it actually executed the faulting instruction, so we don't need to
-  // consult the warp or SM rows to attribute it.
   if (lane.exception != 0) {
     out.attributed_exception = lane.exception;
     return out;
@@ -173,11 +170,9 @@ StopAttribution ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
     return out;
   }
 
-  // Inline `trap;` / `__trap()` shows up here: the CUDA SDK has no
-  // CUDBG_EXCEPTION_TRAP, so a hardcoded trap leaves `lane.exception ==
-  // 0` and `sm.exception == 0` but sets `warp.isWarpBroken`. Scope it to
-  // the active lanes so unrelated lanes on the same warp don't look like
-  // they hit the trap.
+  // The SDK has no `CUDBG_EXCEPTION_TRAP`; an inline trap surfaces as
+  // `isWarpBroken`. Gate by active lane so unrelated lanes on the same
+  // warp don't claim the trap.
   if (warp_or->isWarpBroken && warp_or->IsLaneActive(lane_idx))
     out.warp_broken_active = true;
 

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
@@ -148,12 +148,19 @@ std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane) {
                                  lane.threadIdxZ);
 }
 
-uint32_t ComputeAttributedException(const LaneEntry &lane, uint32_t lane_idx,
-                                    lldb::SectionSP warp_section_sp,
-                                    lldb::SectionSP sm_section_sp,
-                                    ObjectFileELF *core) {
-  if (lane.exception != 0)
-    return lane.exception;
+StopAttribution ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
+                                       lldb::SectionSP warp_section_sp,
+                                       lldb::SectionSP sm_section_sp,
+                                       ObjectFileELF *core) {
+  StopAttribution out;
+
+  // A per-lane exception is definitive: a lane only carries an exception
+  // if it actually executed the faulting instruction, so we don't need to
+  // consult the warp or SM rows to attribute it.
+  if (lane.exception != 0) {
+    out.attributed_exception = lane.exception;
+    return out;
+  }
 
   Log *log = GetLog(LLDBLog::Process);
   llvm::Expected<WarpEntry> warp_or =
@@ -161,22 +168,32 @@ uint32_t ComputeAttributedException(const LaneEntry &lane, uint32_t lane_idx,
   if (!warp_or) {
     LLDB_LOG_ERROR(log, warp_or.takeError(),
                    "Failed to decode GPU warp data while attributing "
-                   "exception to lane {1}: {0}",
+                   "stop reason to lane {1}: {0}",
                    lane_idx);
-    return 0;
+    return out;
   }
+
+  // Inline `trap;` / `__trap()` shows up here: the CUDA SDK has no
+  // CUDBG_EXCEPTION_TRAP, so a hardcoded trap leaves `lane.exception ==
+  // 0` and `sm.exception == 0` but sets `warp.isWarpBroken`. Scope it to
+  // the active lanes so unrelated lanes on the same warp don't look like
+  // they hit the trap.
+  if (warp_or->isWarpBroken && warp_or->IsLaneActive(lane_idx))
+    out.warp_broken_active = true;
+
   if (!warp_or->errorPCValid || !warp_or->IsLaneActive(lane_idx))
-    return 0;
+    return out;
 
   llvm::Expected<SMEntry> sm_or = ReadAndDecode<SMEntry>(sm_section_sp, core);
   if (!sm_or) {
     LLDB_LOG_ERROR(log, sm_or.takeError(),
                    "Failed to decode GPU SM data while attributing "
-                   "exception to lane {1}: {0}",
+                   "stop reason to lane {1}: {0}",
                    lane_idx);
-    return 0;
+    return out;
   }
-  return sm_or->exception;
+  out.attributed_exception = sm_or->exception;
+  return out;
 }
 
 } // namespace lldb_private::nvgpu_core

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
@@ -170,8 +170,7 @@ ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
   // The SDK has no `CUDBG_EXCEPTION_TRAP`; an inline trap surfaces as
   // `isWarpBroken`. Gate by active lane so unrelated lanes on the same
   // warp don't claim the trap.
-  const bool warp_broken_active =
-      warp_or->isWarpBroken && warp_or->IsLaneActive(lane_idx);
+  const bool at_trap = warp_or->isWarpBroken && warp_or->IsLaneActive(lane_idx);
 
   uint32_t attributed_exception = 0;
   std::string decode_error;
@@ -188,9 +187,9 @@ ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
     }
   }
 
-  if (attributed_exception == 0 && !warp_broken_active && decode_error.empty())
+  if (attributed_exception == 0 && !at_trap && decode_error.empty())
     return std::nullopt;
-  return StopAttribution{attributed_exception, warp_broken_active,
+  return StopAttribution{attributed_exception, at_trap,
                          std::move(decode_error)};
 }
 

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
@@ -117,8 +117,24 @@ llvm::Expected<EntryT> ReadAndDecode(lldb::SectionSP section_sp,
 /// fields by hand.
 std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane);
 
-/// Compute the attributed exception code for `lane_idx` using the
-/// standard precedence cascade:
+/// What stopped a lane in a corefile.
+///
+/// A corefile freezes the whole GPU in one shot, so most lanes were
+/// merely suspended and have no per-thread stop reason. The two fields
+/// below capture the only two ways a lane can carry one:
+struct StopAttribution {
+  /// `CUDBGException_t` attributed to this lane via the precedence
+  /// cascade in `ComputeStopAttribution`, or 0 if none applies.
+  uint32_t attributed_exception = 0;
+  /// True if this lane's warp was halted at a hardcoded breakpoint /
+  /// inline `trap;` (`warp.isWarpBroken`) AND this lane was active at
+  /// that moment (`warp.IsLaneActive(lane_idx)`). The active-lane gate
+  /// scopes the trap to the lanes that actually executed it.
+  bool warp_broken_active = false;
+};
+
+/// Compute the stop-attribution facts for `lane_idx` from the lane / warp
+/// / SM rows. The precedence cascade for the exception field is:
 ///
 ///   1. Per-lane exception (`lane.exception`) is definitive when non-zero.
 ///      A lane that didn't execute the faulting instruction can't carry
@@ -129,12 +145,18 @@ std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane);
 ///      `sm.exception`.
 ///   3. Otherwise 0 (`CUDBG_EXCEPTION_NONE`).
 ///
-/// Returns 0 on any read/decode failure of the warp or SM rows; errors
-/// are consumed internally so callers don't have to handle `Expected`.
-uint32_t ComputeAttributedException(const LaneEntry &lane, uint32_t lane_idx,
-                                    lldb::SectionSP warp_section_sp,
-                                    lldb::SectionSP sm_section_sp,
-                                    ObjectFileELF *core);
+/// The `warp_broken_active` flag is independently set from the warp row;
+/// it covers the case where a warp executed an inline `trap;` (which the
+/// CUDA SDK reports via `isWarpBroken`, not via the exception enum -- there
+/// is no `CUDBG_EXCEPTION_TRAP`).
+///
+/// Read/decode failures of the warp or SM rows are consumed internally,
+/// so callers don't have to handle `Expected`; on failure, the
+/// corresponding fields stay at their defaults.
+StopAttribution ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
+                                       lldb::SectionSP warp_section_sp,
+                                       lldb::SectionSP sm_section_sp,
+                                       ObjectFileELF *core);
 
 } // namespace lldb_private::nvgpu_core
 

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
@@ -120,7 +120,7 @@ std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane);
 
 /// Why a corefile lane stopped. Most lanes were merely suspended when
 /// the dump was taken and carry no stop reason; the fields below are
-/// the only two ways a lane can claim one.
+/// the ways a lane can claim one.
 struct StopAttribution {
   /// `CUDBGException_t` attributed to this lane, or 0 if none.
   uint32_t attributed_exception;
@@ -129,6 +129,11 @@ struct StopAttribution {
   /// code). The active-lane gate scopes the trap to lanes that
   /// actually executed it.
   bool warp_broken_active;
+  /// If the warp or SM row failed to decode (typically a truncated
+  /// corefile), a human-readable description of the failure. Surfaced
+  /// as the lane's stop reason so the user sees the corruption in
+  /// `thread list` instead of the lane silently appearing healthy.
+  std::string decode_error;
 };
 
 /// Compute stop attribution for `lane_idx`, or `std::nullopt` if the
@@ -139,8 +144,9 @@ struct StopAttribution {
 ///      fault time, borrow `sm.exception`.
 ///   3. Otherwise no exception.
 ///
-/// Warp/SM read failures are consumed internally and treated as no
-/// attribution.
+/// Warp/SM read failures populate `decode_error` (and are also logged
+/// via the Process log channel) so the failure surfaces to the user as
+/// a stop reason rather than silently disappearing.
 std::optional<StopAttribution>
 ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
                        lldb::SectionSP warp_section_sp,

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
@@ -124,11 +124,11 @@ std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane);
 struct StopAttribution {
   /// `CUDBGException_t` attributed to this lane, or 0 if none.
   uint32_t attributed_exception;
-  /// Lane was active on a warp halted at an inline `trap;` / `__trap()`
-  /// (the SDK reports this via `isWarpBroken`, not via an exception
-  /// code). The active-lane gate scopes the trap to lanes that
-  /// actually executed it.
-  bool warp_broken_active;
+  /// Lane stopped at an inline `trap;` / `__trap()`. The CUDA SDK
+  /// reports this via `warp.isWarpBroken` rather than an exception
+  /// code, gated by the warp's active-lane mask so unrelated lanes on
+  /// the same warp don't claim the trap.
+  bool at_trap;
   /// If the warp or SM row failed to decode (typically a truncated
   /// corefile), a human-readable description of the failure. Surfaced
   /// as the lane's stop reason so the user sees the corruption in

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
@@ -42,6 +42,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <cstdint>
+#include <optional>
 #include <string>
 
 namespace lldb_private::nvgpu_core {
@@ -122,27 +123,28 @@ std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane);
 /// the only two ways a lane can claim one.
 struct StopAttribution {
   /// `CUDBGException_t` attributed to this lane, or 0 if none.
-  uint32_t attributed_exception = 0;
+  uint32_t attributed_exception;
   /// Lane was active on a warp halted at an inline `trap;` / `__trap()`
   /// (the SDK reports this via `isWarpBroken`, not via an exception
   /// code). The active-lane gate scopes the trap to lanes that
   /// actually executed it.
-  bool warp_broken_active = false;
+  bool warp_broken_active;
 };
 
-/// Compute stop attribution for `lane_idx`. Exception precedence:
+/// Compute stop attribution for `lane_idx`, or `std::nullopt` if the
+/// lane has no stop reason. Exception precedence:
 ///
 ///   1. `lane.exception` is definitive when non-zero.
 ///   2. Otherwise, if `warp.errorPCValid` AND the lane was active at
 ///      fault time, borrow `sm.exception`.
-///   3. Otherwise `CUDBG_EXCEPTION_NONE`.
+///   3. Otherwise no exception.
 ///
-/// Warp/SM read failures are consumed internally; affected fields are
-/// left at their defaults.
-StopAttribution ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
-                                       lldb::SectionSP warp_section_sp,
-                                       lldb::SectionSP sm_section_sp,
-                                       ObjectFileELF *core);
+/// Warp/SM read failures are consumed internally and treated as no
+/// attribution.
+std::optional<StopAttribution>
+ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
+                       lldb::SectionSP warp_section_sp,
+                       lldb::SectionSP sm_section_sp, ObjectFileELF *core);
 
 } // namespace lldb_private::nvgpu_core
 

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
@@ -117,42 +117,28 @@ llvm::Expected<EntryT> ReadAndDecode(lldb::SectionSP section_sp,
 /// fields by hand.
 std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane);
 
-/// What stopped a lane in a corefile.
-///
-/// A corefile freezes the whole GPU in one shot, so most lanes were
-/// merely suspended and have no per-thread stop reason. The two fields
-/// below capture the only two ways a lane can carry one:
+/// Why a corefile lane stopped. Most lanes were merely suspended when
+/// the dump was taken and carry no stop reason; the fields below are
+/// the only two ways a lane can claim one.
 struct StopAttribution {
-  /// `CUDBGException_t` attributed to this lane via the precedence
-  /// cascade in `ComputeStopAttribution`, or 0 if none applies.
+  /// `CUDBGException_t` attributed to this lane, or 0 if none.
   uint32_t attributed_exception = 0;
-  /// True if this lane's warp was halted at a hardcoded breakpoint /
-  /// inline `trap;` (`warp.isWarpBroken`) AND this lane was active at
-  /// that moment (`warp.IsLaneActive(lane_idx)`). The active-lane gate
-  /// scopes the trap to the lanes that actually executed it.
+  /// Lane was active on a warp halted at an inline `trap;` / `__trap()`
+  /// (the SDK reports this via `isWarpBroken`, not via an exception
+  /// code). The active-lane gate scopes the trap to lanes that
+  /// actually executed it.
   bool warp_broken_active = false;
 };
 
-/// Compute the stop-attribution facts for `lane_idx` from the lane / warp
-/// / SM rows. The precedence cascade for the exception field is:
+/// Compute stop attribution for `lane_idx`. Exception precedence:
 ///
-///   1. Per-lane exception (`lane.exception`) is definitive when non-zero.
-///      A lane that didn't execute the faulting instruction can't carry
-///      an exception from it.
-///   2. Otherwise, if this lane's warp caused the SM fault
-///      (`warp.errorPCValid`) AND this lane was active at fault time
-///      (`warp.IsLaneActive(lane_idx)`), borrow the kind from
-///      `sm.exception`.
-///   3. Otherwise 0 (`CUDBG_EXCEPTION_NONE`).
+///   1. `lane.exception` is definitive when non-zero.
+///   2. Otherwise, if `warp.errorPCValid` AND the lane was active at
+///      fault time, borrow `sm.exception`.
+///   3. Otherwise `CUDBG_EXCEPTION_NONE`.
 ///
-/// The `warp_broken_active` flag is independently set from the warp row;
-/// it covers the case where a warp executed an inline `trap;` (which the
-/// CUDA SDK reports via `isWarpBroken`, not via the exception enum -- there
-/// is no `CUDBG_EXCEPTION_TRAP`).
-///
-/// Read/decode failures of the warp or SM rows are consumed internally,
-/// so callers don't have to handle `Expected`; on failure, the
-/// corresponding fields stay at their defaults.
+/// Warp/SM read failures are consumed internally; affected fields are
+/// left at their defaults.
 StopAttribution ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
                                        lldb::SectionSP warp_section_sp,
                                        lldb::SectionSP sm_section_sp,

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
@@ -244,12 +244,18 @@ bool ProcessNVGPUCore::DoUpdateThreadList(ThreadList &old_thread_list,
           std::make_shared<ThreadNVGPUCore>(*this, tid, lane, lane_idx);
       new_thread_list.AddThread(thread_sp);
 
-      // Select the first thread that any CUDA exception is attributed to
-      // (matches ThreadNVGPUCore::CalculateStopInfo's policy, so thread
-      // selection and stop reason stay consistent).
+      // Pick a thread to surface to the user. Mirrors the precedence
+      // baked into ThreadNVGPUCore::CalculateStopInfo so the selected
+      // thread is always one of the ones that has a non-None stop
+      // reason: prefer a CUDA exception thread, then fall back to a
+      // lane stopped on an inline trap;/__trap().
       if (m_exception_tid == LLDB_INVALID_THREAD_ID &&
-          thread_sp->GetAttributedException() != 0)
+          thread_sp->GetAttributedException() != 0) {
         m_exception_tid = tid;
+      } else if (m_stop_tid == LLDB_INVALID_THREAD_ID &&
+                 thread_sp->IsWarpBrokenForThisLane()) {
+        m_stop_tid = tid;
+      }
     }
   }
 

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
@@ -250,7 +250,7 @@ bool ProcessNVGPUCore::DoUpdateThreadList(ThreadList &old_thread_list,
           thread_sp->GetAttributedException() != 0) {
         m_exception_tid = tid;
       } else if (m_stop_tid == LLDB_INVALID_THREAD_ID &&
-                 thread_sp->IsWarpBrokenForThisLane()) {
+                 thread_sp->IsAtTrap()) {
         m_stop_tid = tid;
       }
     }

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
@@ -244,11 +244,8 @@ bool ProcessNVGPUCore::DoUpdateThreadList(ThreadList &old_thread_list,
           std::make_shared<ThreadNVGPUCore>(*this, tid, lane, lane_idx);
       new_thread_list.AddThread(thread_sp);
 
-      // Pick a thread to surface to the user. Mirrors the precedence
-      // baked into ThreadNVGPUCore::CalculateStopInfo so the selected
-      // thread is always one of the ones that has a non-None stop
-      // reason: prefer a CUDA exception thread, then fall back to a
-      // lane stopped on an inline trap;/__trap().
+      // Remember the first thread of each stop kind so an interesting
+      // thread is auto-selected: prefer an exception, fall back to a trap.
       if (m_exception_tid == LLDB_INVALID_THREAD_ID &&
           thread_sp->GetAttributedException() != 0) {
         m_exception_tid = tid;

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
@@ -54,12 +54,16 @@ public:
   lldb_private::Status DoDestroy() override { return lldb_private::Status(); }
 
   void RefreshStateAfterStop() override {
-    // Prefer an exception thread, then a trap thread; otherwise leave
-    // selection at the default.
+    // Prefer an exception thread, then a trap thread; otherwise fall
+    // back to the first thread we created.
     if (m_exception_tid != LLDB_INVALID_THREAD_ID)
       GetThreadList().SetSelectedThreadByID(m_exception_tid);
     else if (m_stop_tid != LLDB_INVALID_THREAD_ID)
       GetThreadList().SetSelectedThreadByID(m_stop_tid);
+    else {
+      if (lldb::ThreadSP first = GetThreadList().GetThreadAtIndex(0))
+        GetThreadList().SetSelectedThreadByID(first->GetID());
+    }
   }
 
   lldb_private::Status WillResume() override {

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
@@ -54,10 +54,8 @@ public:
   lldb_private::Status DoDestroy() override { return lldb_private::Status(); }
 
   void RefreshStateAfterStop() override {
-    // Prefer the exception thread; fall back to a lane stopped on an
-    // inline trap;/__trap(). If neither exists, leave selection to the
-    // default (`StopInfo::ShouldSelect()` already prefers any non-None
-    // reason over None, which is what we want).
+    // Prefer an exception thread, then a trap thread; otherwise leave
+    // selection at the default.
     if (m_exception_tid != LLDB_INVALID_THREAD_ID)
       GetThreadList().SetSelectedThreadByID(m_exception_tid);
     else if (m_stop_tid != LLDB_INVALID_THREAD_ID)
@@ -107,11 +105,9 @@ private:
 
   lldb::ModuleSP m_core_module_sp;
   lldb::SectionSP m_root_sp;
-  /// First thread with an attributed CUDA exception, or
-  /// `LLDB_INVALID_THREAD_ID` if no lane faulted in this corefile.
+  /// First thread with an attributed CUDA exception.
   lldb::tid_t m_exception_tid = LLDB_INVALID_THREAD_ID;
-  /// First thread on a warp halted at an inline `trap;` / `__trap()`,
-  /// used as the secondary selection if there's no exception thread.
+  /// First thread stopped on an inline `trap;` / `__trap()`.
   lldb::tid_t m_stop_tid = LLDB_INVALID_THREAD_ID;
 };
 

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
@@ -54,8 +54,14 @@ public:
   lldb_private::Status DoDestroy() override { return lldb_private::Status(); }
 
   void RefreshStateAfterStop() override {
+    // Prefer the exception thread; fall back to a lane stopped on an
+    // inline trap;/__trap(). If neither exists, leave selection to the
+    // default (`StopInfo::ShouldSelect()` already prefers any non-None
+    // reason over None, which is what we want).
     if (m_exception_tid != LLDB_INVALID_THREAD_ID)
       GetThreadList().SetSelectedThreadByID(m_exception_tid);
+    else if (m_stop_tid != LLDB_INVALID_THREAD_ID)
+      GetThreadList().SetSelectedThreadByID(m_stop_tid);
   }
 
   lldb_private::Status WillResume() override {
@@ -101,7 +107,12 @@ private:
 
   lldb::ModuleSP m_core_module_sp;
   lldb::SectionSP m_root_sp;
+  /// First thread with an attributed CUDA exception, or
+  /// `LLDB_INVALID_THREAD_ID` if no lane faulted in this corefile.
   lldb::tid_t m_exception_tid = LLDB_INVALID_THREAD_ID;
+  /// First thread on a warp halted at an inline `trap;` / `__trap()`,
+  /// used as the secondary selection if there's no exception thread.
+  lldb::tid_t m_stop_tid = LLDB_INVALID_THREAD_ID;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_PROCESS_NVGPU_CORE_PROCESSNVGPUCORE_H

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
@@ -31,8 +31,9 @@ ThreadNVGPUCore::ThreadNVGPUCore(Process &process, tid_t tid,
   // Eagerly decode the CTA and lane rows once at construction time so:
   //   * `m_name` (used by `GetName()`) is a cached string, not a re-decode
   //     of CTA+lane on every call to LLDB's stop-reason printers.
-  //   * `m_attributed_exception` (used by `GetAttributedException()` and
-  //     `CalculateStopInfo`) is a cached field. `ComputeAttributedException`
+  //   * `m_attributed_exception` and `m_warp_broken_active` (used by
+  //     `GetAttributedException()` / `IsWarpBrokenForThisLane()` and
+  //     `CalculateStopInfo`) are cached fields. `ComputeStopAttribution`
   //     decodes the warp (and on cascade, the SM) row internally.
   auto &nvgpu_process = static_cast<ProcessNVGPUCore &>(process);
   ObjectFileELF *core = nvgpu_process.GetCoreObjectFile();
@@ -46,9 +47,13 @@ ThreadNVGPUCore::ThreadNVGPUCore(Process &process, tid_t tid,
   if (m_name.empty())
     m_name = "NVIDIA GPU Thread";
 
-  if (lane_or)
-    m_attributed_exception = nvgpu_core::ComputeAttributedException(
-        *lane_or, GetLaneIndex(), GetWarpSection(), GetSMSection(), core);
+  if (lane_or) {
+    nvgpu_core::StopAttribution attribution =
+        nvgpu_core::ComputeStopAttribution(
+            *lane_or, GetLaneIndex(), GetWarpSection(), GetSMSection(), core);
+    m_attributed_exception = attribution.attributed_exception;
+    m_warp_broken_active = attribution.warp_broken_active;
+  }
 
   Log *log = GetLog(LLDBLog::Process);
   if (!cta_or)
@@ -104,15 +109,25 @@ ThreadNVGPUCore::CreateRegisterContextForFrame(StackFrame *frame) {
 const char *ThreadNVGPUCore::GetName() { return m_name.c_str(); }
 
 bool ThreadNVGPUCore::CalculateStopInfo() {
+  // Three buckets:
+  //   1. Attributed CUDA exception -> "stop reason = CUDA Exception: ...".
+  //   2. Lane was active on a warp halted at an inline trap;/__trap()
+  //      (`warp.isWarpBroken`) -> "stop reason = signal SIGTRAP (trap)".
+  //      The active-lane gate is applied in ComputeStopAttribution so
+  //      unrelated lanes on the same warp don't claim the trap.
+  //   3. Otherwise -> no stop reason. A corefile freezes the GPU as a
+  //      whole; lanes that didn't fault and didn't trap were merely
+  //      suspended, so leaving m_stop_info_sp null (yielding
+  //      eStopReasonNone) keeps `thread list` from misreporting SIGTRAP
+  //      on every lane in the dump.
   CUDBGException_t exc =
       static_cast<CUDBGException_t>(GetAttributedException());
   if (exc != CUDBG_EXCEPTION_NONE) {
     std::string desc =
         ("CUDA Exception: " + CUDAExceptionToString(exc)).str();
     SetStopInfo(StopInfo::CreateStopReasonWithException(*this, desc.c_str()));
-  } else {
-    SetStopInfo(StopInfo::CreateStopReasonWithSignal(*this, SIGTRAP));
+  } else if (IsWarpBrokenForThisLane()) {
+    SetStopInfo(StopInfo::CreateStopReasonWithSignal(*this, SIGTRAP, "trap"));
   }
-
   return true;
 }

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
@@ -112,7 +112,7 @@ bool ThreadNVGPUCore::CalculateStopInfo() {
   if (exc != CUDBG_EXCEPTION_NONE) {
     std::string desc = ("CUDA Exception: " + CUDAExceptionToString(exc)).str();
     SetStopInfo(StopInfo::CreateStopReasonWithException(*this, desc.c_str()));
-  } else if (m_stop_attribution->warp_broken_active) {
+  } else if (m_stop_attribution->at_trap) {
     SetStopInfo(StopInfo::CreateStopReasonWithSignal(*this, SIGTRAP, "trap"));
   } else if (!m_stop_attribution->decode_error.empty()) {
     std::string desc = "error: " + m_stop_attribution->decode_error;

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
@@ -42,15 +42,9 @@ ThreadNVGPUCore::ThreadNVGPUCore(Process &process, tid_t tid,
   if (m_name.empty())
     m_name = "NVIDIA GPU Thread";
 
-  if (lane_or) {
-    std::optional<nvgpu_core::StopAttribution> attribution =
-        nvgpu_core::ComputeStopAttribution(
-            *lane_or, GetLaneIndex(), GetWarpSection(), GetSMSection(), core);
-    if (attribution) {
-      m_attributed_exception = attribution->attributed_exception;
-      m_warp_broken_active = attribution->warp_broken_active;
-    }
-  }
+  if (lane_or)
+    m_stop_attribution = nvgpu_core::ComputeStopAttribution(
+        *lane_or, GetLaneIndex(), GetWarpSection(), GetSMSection(), core);
 
   Log *log = GetLog(LLDBLog::Process);
   if (!cta_or)
@@ -106,16 +100,23 @@ ThreadNVGPUCore::CreateRegisterContextForFrame(StackFrame *frame) {
 const char *ThreadNVGPUCore::GetName() { return m_name.c_str(); }
 
 bool ThreadNVGPUCore::CalculateStopInfo() {
-  // Only faulted lanes and trap'd lanes carry a stop reason; merely
-  // suspended lanes are left with no stop info so they don't appear to
-  // have hit SIGTRAP in the dump.
+  // A lane gets a stop reason if it faulted, trap'd, or had its row
+  // data fail to decode (surfaced so corrupt corefiles don't silently
+  // look healthy). Otherwise it's left with no stop info so suspended
+  // lanes don't appear to have hit SIGTRAP.
+  if (!m_stop_attribution)
+    return true;
+
   CUDBGException_t exc =
-      static_cast<CUDBGException_t>(GetAttributedException());
+      static_cast<CUDBGException_t>(m_stop_attribution->attributed_exception);
   if (exc != CUDBG_EXCEPTION_NONE) {
     std::string desc = ("CUDA Exception: " + CUDAExceptionToString(exc)).str();
     SetStopInfo(StopInfo::CreateStopReasonWithException(*this, desc.c_str()));
-  } else if (IsWarpBrokenForThisLane()) {
+  } else if (m_stop_attribution->warp_broken_active) {
     SetStopInfo(StopInfo::CreateStopReasonWithSignal(*this, SIGTRAP, "trap"));
+  } else if (!m_stop_attribution->decode_error.empty()) {
+    std::string desc = "error: " + m_stop_attribution->decode_error;
+    SetStopInfo(StopInfo::CreateStopReasonWithException(*this, desc.c_str()));
   }
   return true;
 }

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
@@ -28,13 +28,8 @@ ThreadNVGPUCore::ThreadNVGPUCore(Process &process, tid_t tid,
                                  SectionSP lane_section_sp, uint32_t lane_idx)
     : Thread(process, tid), m_lane_section_sp(std::move(lane_section_sp)),
       m_lane_idx(lane_idx) {
-  // Eagerly decode the CTA and lane rows once at construction time so:
-  //   * `m_name` (used by `GetName()`) is a cached string, not a re-decode
-  //     of CTA+lane on every call to LLDB's stop-reason printers.
-  //   * `m_attributed_exception` and `m_warp_broken_active` (used by
-  //     `GetAttributedException()` / `IsWarpBrokenForThisLane()` and
-  //     `CalculateStopInfo`) are cached fields. `ComputeStopAttribution`
-  //     decodes the warp (and on cascade, the SM) row internally.
+  // Decode the CTA and lane rows once so the thread name and stop
+  // attribution are cached, instead of re-decoding on every query.
   auto &nvgpu_process = static_cast<ProcessNVGPUCore &>(process);
   ObjectFileELF *core = nvgpu_process.GetCoreObjectFile();
   auto cta_or =
@@ -109,17 +104,9 @@ ThreadNVGPUCore::CreateRegisterContextForFrame(StackFrame *frame) {
 const char *ThreadNVGPUCore::GetName() { return m_name.c_str(); }
 
 bool ThreadNVGPUCore::CalculateStopInfo() {
-  // Three buckets:
-  //   1. Attributed CUDA exception -> "stop reason = CUDA Exception: ...".
-  //   2. Lane was active on a warp halted at an inline trap;/__trap()
-  //      (`warp.isWarpBroken`) -> "stop reason = signal SIGTRAP (trap)".
-  //      The active-lane gate is applied in ComputeStopAttribution so
-  //      unrelated lanes on the same warp don't claim the trap.
-  //   3. Otherwise -> no stop reason. A corefile freezes the GPU as a
-  //      whole; lanes that didn't fault and didn't trap were merely
-  //      suspended, so leaving m_stop_info_sp null (yielding
-  //      eStopReasonNone) keeps `thread list` from misreporting SIGTRAP
-  //      on every lane in the dump.
+  // Only faulted lanes and trap'd lanes carry a stop reason; merely
+  // suspended lanes are left with no stop info so they don't appear to
+  // have hit SIGTRAP in the dump.
   CUDBGException_t exc =
       static_cast<CUDBGException_t>(GetAttributedException());
   if (exc != CUDBG_EXCEPTION_NONE) {

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
@@ -43,11 +43,13 @@ ThreadNVGPUCore::ThreadNVGPUCore(Process &process, tid_t tid,
     m_name = "NVIDIA GPU Thread";
 
   if (lane_or) {
-    nvgpu_core::StopAttribution attribution =
+    std::optional<nvgpu_core::StopAttribution> attribution =
         nvgpu_core::ComputeStopAttribution(
             *lane_or, GetLaneIndex(), GetWarpSection(), GetSMSection(), core);
-    m_attributed_exception = attribution.attributed_exception;
-    m_warp_broken_active = attribution.warp_broken_active;
+    if (attribution) {
+      m_attributed_exception = attribution->attributed_exception;
+      m_warp_broken_active = attribution->warp_broken_active;
+    }
   }
 
   Log *log = GetLog(LLDBLog::Process);
@@ -110,8 +112,7 @@ bool ThreadNVGPUCore::CalculateStopInfo() {
   CUDBGException_t exc =
       static_cast<CUDBGException_t>(GetAttributedException());
   if (exc != CUDBG_EXCEPTION_NONE) {
-    std::string desc =
-        ("CUDA Exception: " + CUDAExceptionToString(exc)).str();
+    std::string desc = ("CUDA Exception: " + CUDAExceptionToString(exc)).str();
     SetStopInfo(StopInfo::CreateStopReasonWithException(*this, desc.c_str()));
   } else if (IsWarpBrokenForThisLane()) {
     SetStopInfo(StopInfo::CreateStopReasonWithSignal(*this, SIGTRAP, "trap"));

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.h
@@ -63,6 +63,12 @@ public:
   /// fault.
   uint32_t GetAttributedException() const { return m_attributed_exception; }
 
+  /// True if this thread's warp was halted at an inline `trap;` /
+  /// `__trap()` (`warp.isWarpBroken`) and this lane was active at that
+  /// moment. Distinguishes a real trap hit from a lane that was merely
+  /// suspended when the corefile was taken.
+  bool IsWarpBrokenForThisLane() const { return m_warp_broken_active; }
+
 protected:
   bool CalculateStopInfo() override;
 
@@ -71,6 +77,7 @@ private:
   uint32_t m_lane_idx;
   std::string m_name;
   uint32_t m_attributed_exception = 0;
+  bool m_warp_broken_active = false;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.h
@@ -69,10 +69,9 @@ public:
     return m_stop_attribution ? m_stop_attribution->attributed_exception : 0;
   }
 
-  /// True if this lane was active on a warp halted at an inline `trap;`
-  /// / `__trap()`.
-  bool IsWarpBrokenForThisLane() const {
-    return m_stop_attribution && m_stop_attribution->warp_broken_active;
+  /// True if this lane stopped at an inline `trap;` / `__trap()`.
+  bool IsAtTrap() const {
+    return m_stop_attribution && m_stop_attribution->at_trap;
   }
 
 protected:

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.h
@@ -9,8 +9,12 @@
 #ifndef LLDB_SOURCE_PLUGINS_PROCESS_NVGPU_CORE_THREADNVGPUCORE_H
 #define LLDB_SOURCE_PLUGINS_PROCESS_NVGPU_CORE_THREADNVGPUCORE_H
 
+#include "CudbgEntryParser.h"
+
 #include "lldb/Target/Thread.h"
 #include "lldb/lldb-forward.h"
+
+#include <optional>
 
 namespace lldb_private {
 
@@ -61,11 +65,15 @@ public:
   /// Return the CUDA exception code attributed to this thread, or
   /// `CUDBG_EXCEPTION_NONE` (zero) if this thread did not participate in a
   /// fault.
-  uint32_t GetAttributedException() const { return m_attributed_exception; }
+  uint32_t GetAttributedException() const {
+    return m_stop_attribution ? m_stop_attribution->attributed_exception : 0;
+  }
 
   /// True if this lane was active on a warp halted at an inline `trap;`
   /// / `__trap()`.
-  bool IsWarpBrokenForThisLane() const { return m_warp_broken_active; }
+  bool IsWarpBrokenForThisLane() const {
+    return m_stop_attribution && m_stop_attribution->warp_broken_active;
+  }
 
 protected:
   bool CalculateStopInfo() override;
@@ -74,8 +82,7 @@ private:
   lldb::SectionSP m_lane_section_sp;
   uint32_t m_lane_idx;
   std::string m_name;
-  uint32_t m_attributed_exception = 0;
-  bool m_warp_broken_active = false;
+  std::optional<nvgpu_core::StopAttribution> m_stop_attribution;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.h
@@ -63,10 +63,8 @@ public:
   /// fault.
   uint32_t GetAttributedException() const { return m_attributed_exception; }
 
-  /// True if this thread's warp was halted at an inline `trap;` /
-  /// `__trap()` (`warp.isWarpBroken`) and this lane was active at that
-  /// moment. Distinguishes a real trap hit from a lane that was merely
-  /// suspended when the corefile was taken.
+  /// True if this lane was active on a warp halted at an inline `trap;`
+  /// / `__trap()`.
   bool IsWarpBrokenForThisLane() const { return m_warp_broken_active; }
 
 protected:


### PR DESCRIPTION
ThreadNVGPUCore::CalculateStopInfo assigned SIGTRAP to every lane without an attributed CUDA exception, so a coredump with one inline `trap;` and 58k merely-suspended lanes looked like 58k threads had all hit SIGTRAP. Use the corefile's `CudbgWarpTableEntry::isWarpBroken` (SDK analog of the live `CUDBG_BREAKPOINT_HANDLE_TRAP`) to scope SIGTRAP to lanes active on a warp halted at an inline `trap;` / `__trap()`; lanes that neither faulted nor trap'd now have no stop reason. ProcessNVGPUCore::DoUpdateThreadList grows a secondary fallback so a trap'd lane is auto-selected when there is no exception thread.

ComputeAttributedException becomes ComputeStopAttribution, which returns both attribution facts from one warp decode.