### PR TITLE
[LLDB][NVGPU] Better thread list aggregation on NVIDIA GPU targets

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -1053,11 +1053,20 @@ public:
   /// \param[in] only_threads_with_stop_reason
   ///     If true, only threads with a valid stop reason will be displayed.
   ///
+  /// \param[in] stop_reason_filter
+  ///     If non-empty, only show threads whose stop reason matches this
+  ///     filter. The platform decides how the filter is interpreted; the
+  ///     NVGPU plugin accepts the keyword `exception` (any CUDA exception),
+  ///     `signal` (any signal stop), a specific signal name (e.g.
+  ///     `SIGTRAP`), or any substring of the stop-reason description.
+  ///     Threads that do not match are folded into a single summary row.
+  ///
   /// \returns
   ///     The number of threads whose status was printed, or 0 if this
   ///     platform does not provide custom GPU thread status handling.
   virtual size_t GetGPUThreadStatus(Process &process, Stream &strm,
-                                    bool only_threads_with_stop_reason) {
+                                    bool only_threads_with_stop_reason,
+                                    llvm::StringRef stop_reason_filter = {}) {
     return 0;
   }
 

--- a/lldb/packages/Python/lldbsuite/test/tools/gpu/nvgpu_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/gpu/nvgpu_testcase.py
@@ -12,7 +12,15 @@ class NVGPUTestCaseBase(GpuTestCaseBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     def killCPUOnTeardown(self):
-        self.addTearDownHook(lambda: self.cpu_process.Kill())
+        # TestBase.tearDown deletes all targets (and kills their processes)
+        # before running registered hooks, so by the time this fires
+        # self.cpu_process may already be gone. Guard against that instead
+        # of blowing up the test with an AttributeError.
+        def kill_cpu():
+            proc = self.cpu_process
+            if proc:
+                proc.Kill()
+        self.addTearDownHook(kill_cpu)
 
     def continue_cpu_and_wait_for_gpu_to_stop(self):
         """Resume the CPU process and wait for the GPU process to stop. The gpu_target must be already running."""

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -1321,9 +1321,48 @@ protected:
 };
 
 // CommandObjectThreadList
+#define LLDB_OPTIONS_thread_list
+#include "CommandOptions.inc"
 
 class CommandObjectThreadList : public CommandObjectParsed {
 public:
+  class CommandOptions : public Options {
+  public:
+    CommandOptions() { OptionParsingStarting(nullptr); }
+
+    ~CommandOptions() override = default;
+
+    void OptionParsingStarting(ExecutionContext *execution_context) override {
+      m_verbose = false;
+      m_stop_reason_filter.clear();
+    }
+
+    Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_arg,
+                          ExecutionContext *execution_context) override {
+      const int short_option = m_getopt_table[option_idx].val;
+      Status error;
+
+      switch (short_option) {
+      case 'v':
+        m_verbose = true;
+        break;
+      case 's':
+        m_stop_reason_filter = option_arg.str();
+        break;
+      default:
+        llvm_unreachable("Unimplemented option");
+      }
+      return error;
+    }
+
+    llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
+      return llvm::ArrayRef(g_thread_list_options);
+    }
+
+    bool m_verbose;
+    std::string m_stop_reason_filter;
+  };
+
   CommandObjectThreadList(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "thread list",
@@ -1336,6 +1375,8 @@ public:
 
   ~CommandObjectThreadList() override = default;
 
+  Options *GetOptions() override { return &m_options; }
+
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     Stream &strm = result.GetOutputStream();
@@ -1343,27 +1384,70 @@ protected:
     Process *process = m_exe_ctx.GetProcessPtr();
     const bool only_threads_with_stop_reason = false;
 
-    // Check if this is a GPU target and delegate to the platform plugin if so.
+    // GPU targets get the aggregated platform path by default. `-v` opts out
+    // of the GPU-specific aggregation entirely and uses the same per-thread
+    // rendering as the rest of LLDB; this lets the user fall back to a
+    // detailed view (or filter the per-thread view via `-s`).
     Target &target = process->GetTarget();
-    if (target.IsGPUTarget()) {
+    if (target.IsGPUTarget() && !m_options.m_verbose) {
       PlatformSP platform_sp = target.GetPlatform();
       if (platform_sp) {
-        size_t num_printed =
-            platform_sp->GetGPUThreadStatus(*process, strm,
-                                            only_threads_with_stop_reason);
+        size_t num_printed = platform_sp->GetGPUThreadStatus(
+            *process, strm, only_threads_with_stop_reason,
+            m_options.m_stop_reason_filter);
         if (num_printed > 0)
           return;
-        // Fall through to default behavior if the platform didn't handle it.
       }
+    }
+
+    process->GetStatus(strm);
+
+    if (target.IsGPUTarget() && !m_options.m_stop_reason_filter.empty()) {
+      // -v with --stop-reason on a GPU target: per-thread rendering, filtered
+      // to threads whose stop reason matches. Mirrors Process::GetThreadStatus
+      // but with the extra filter applied at iteration time.
+      llvm::StringRef filter(m_options.m_stop_reason_filter);
+      auto matches = [&](Thread &thread) -> bool {
+        StopInfoSP stop_info_sp = thread.GetStopInfo();
+        if (!stop_info_sp)
+          return false;
+        if (filter.equals_insensitive("exception"))
+          return stop_info_sp->GetStopReason() == lldb::eStopReasonException;
+        if (filter.equals_insensitive("signal"))
+          return stop_info_sp->GetStopReason() == lldb::eStopReasonSignal;
+        if (const char *desc = stop_info_sp->GetDescription())
+          return llvm::StringRef(desc).contains_insensitive(filter);
+        return false;
+      };
+
+      llvm::SmallVector<ThreadSP, 64> threads;
+      {
+        std::lock_guard<std::recursive_mutex> guard(
+            process->GetThreadList().GetMutex());
+        ThreadList &thread_list = process->GetThreadList();
+        uint32_t num_threads = thread_list.GetSize();
+        threads.reserve(num_threads);
+        for (uint32_t i = 0; i < num_threads; ++i)
+          threads.push_back(thread_list.GetThreadAtIndex(i));
+      }
+      for (const ThreadSP &thread_sp : threads) {
+        if (!thread_sp || !matches(*thread_sp))
+          continue;
+        thread_sp->GetStatus(strm, /*start_frame=*/0, /*num_frames=*/0,
+                             /*num_frames_with_source=*/0, /*stop_format=*/false,
+                             /*show_hidden=*/true);
+      }
+      return;
     }
 
     const uint32_t start_frame = 0;
     const uint32_t num_frames = 0;
     const uint32_t num_frames_with_source = 0;
-    process->GetStatus(strm);
     process->GetThreadStatus(strm, only_threads_with_stop_reason, start_frame,
                              num_frames, num_frames_with_source, false);
   }
+
+  CommandOptions m_options;
 };
 
 // CommandObjectThreadInfo

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -1861,6 +1861,21 @@ let Command = "thread until" in {
              "or leave the function - can be specified multiple times.">;
 }
 
+let Command = "thread list" in {
+  def thread_list_verbose : Option<"verbose", "v">,
+    Desc<"For GPU targets, disable platform-specific aggregation and render "
+         "one row per thread, the same way `thread list` works for CPU "
+         "targets.">;
+  def thread_list_stop_reason : Option<"stop-reason", "s">, Arg<"Name">,
+    Desc<"For GPU targets, only show threads whose stop reason matches the "
+         "given filter. Accepts the keyword 'exception' to match any GPU "
+         "exception, the keyword 'signal' to match any signal stop, a "
+         "specific signal name (e.g. SIGTRAP), or any substring of the stop "
+         "reason description (e.g. 'MMU' to match 'Warp MMU Fault'). "
+         "Threads that do not match the filter are summarised in a single "
+         "trailing row.">;
+}
+
 let Command = "thread info" in {
   def thread_info_json : Option<"json", "j">,
                          Desc<"Display the thread info in"

--- a/lldb/source/Plugins/Platform/NVGPU/PlatformNVGPU.cpp
+++ b/lldb/source/Plugins/Platform/NVGPU/PlatformNVGPU.cpp
@@ -30,6 +30,7 @@
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
 #include "llvm/TargetParser/Triple.h"
 
 #include <climits>
@@ -1062,12 +1063,18 @@ static void RenderAggregatedGroup(Stream &strm, const ThreadGroup &group) {
     module_name = sc.module_sp->GetFileSpec().GetFilename();
 
   switch (group.key.kind) {
-  case GroupKind::LineAndFunction:
+  case GroupKind::LineAndFunction: {
     if (module_name)
       strm.Printf("%s`", module_name.GetCString());
+    // Display just the basename so the source location reads like the rest
+    // of LLDB output (`module`function at file.cu:line`). The full path is
+    // retained in the GroupKey for equality so that two files with the same
+    // basename but different paths still hash to distinct groups.
+    llvm::StringRef basename = llvm::sys::path::filename(group.key.file);
     strm.Printf("%s at %s:%u", group.key.function.c_str(),
-                group.key.file.c_str(), group.key.line);
+                basename.str().c_str(), group.key.line);
     break;
+  }
   case GroupKind::FunctionOnly:
     if (module_name)
       strm.Printf("%s`", module_name.GetCString());

--- a/lldb/source/Plugins/Platform/NVGPU/PlatformNVGPU.cpp
+++ b/lldb/source/Plugins/Platform/NVGPU/PlatformNVGPU.cpp
@@ -8,6 +8,7 @@
 
 #include "PlatformNVGPU.h"
 #include "cudadebugger.h"
+#include "lldb/Core/Address.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Symbol/Function.h"
@@ -24,9 +25,14 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/Stream.h"
 
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/TargetParser/Triple.h"
 
+#include <climits>
 #include <map>
 #include <regex>
 
@@ -586,18 +592,6 @@ struct Dim3 {
   int x = 0;
   int y = 0;
   int z = 0;
-
-  bool operator==(const Dim3 &other) const {
-    return x == other.x && y == other.y && z == other.z;
-  }
-
-  bool operator<(const Dim3 &other) const {
-    if (z != other.z)
-      return z < other.z;
-    if (y != other.y)
-      return y < other.y;
-    return x < other.x;
-  }
 };
 
 /// Represents a CUDA thread's full coordinates.
@@ -605,44 +599,6 @@ struct CUDAThreadCoord {
   Dim3 block_idx;
   Dim3 thread_idx;
   lldb::tid_t tid = LLDB_INVALID_THREAD_ID;
-
-  bool operator<(const CUDAThreadCoord &other) const {
-    if (block_idx < other.block_idx)
-      return true;
-    if (other.block_idx < block_idx)
-      return false;
-    return thread_idx < other.thread_idx;
-  }
-};
-
-/// Represents a range of CUDA thread coordinates that share the same PC.
-struct CUDAThreadRange {
-  Dim3 block_min;
-  Dim3 block_max;
-  Dim3 thread_min;
-  Dim3 thread_max;
-  size_t count = 0;
-
-  void AddCoord(const CUDAThreadCoord &coord) {
-    if (count == 0) {
-      block_min = block_max = coord.block_idx;
-      thread_min = thread_max = coord.thread_idx;
-    } else {
-      block_min.x = std::min(block_min.x, coord.block_idx.x);
-      block_min.y = std::min(block_min.y, coord.block_idx.y);
-      block_min.z = std::min(block_min.z, coord.block_idx.z);
-      block_max.x = std::max(block_max.x, coord.block_idx.x);
-      block_max.y = std::max(block_max.y, coord.block_idx.y);
-      block_max.z = std::max(block_max.z, coord.block_idx.z);
-      thread_min.x = std::min(thread_min.x, coord.thread_idx.x);
-      thread_min.y = std::min(thread_min.y, coord.thread_idx.y);
-      thread_min.z = std::min(thread_min.z, coord.thread_idx.z);
-      thread_max.x = std::max(thread_max.x, coord.thread_idx.x);
-      thread_max.y = std::max(thread_max.y, coord.thread_idx.y);
-      thread_max.z = std::max(thread_max.z, coord.thread_idx.z);
-    }
-    ++count;
-  }
 };
 
 /// Parse a CUDA thread name in the format:
@@ -667,76 +623,254 @@ static bool ParseCUDAThreadName(llvm::StringRef name, CUDAThreadCoord &coord) {
   return true;
 }
 
-/// Format a dimension range, showing just the value if min==max,
-/// or [min...max] if they differ.
-static void FormatDimRange(Stream &strm, const char *name, int min_val,
-                           int max_val) {
-  if (min_val == max_val)
-    strm.Printf("%s=%d", name, min_val);
-  else
-    strm.Printf("%s=[%d...%d]", name, min_val, max_val);
-}
+/// Per-dimension value tracker for the aggregated thread-list path.
+///
+/// Stores every distinct value seen for a single CUDA coordinate dimension
+/// (e.g. blockIdx.x) within a group, so we can decide between three display
+/// forms: a single value, a contiguous range, or a wildcard when the values
+/// are non-contiguous.
+struct DimSet {
+  int min_v = INT_MAX;
+  int max_v = INT_MIN;
+  llvm::DenseSet<int> values;
 
-/// Format a Dim3 range for display.
-static void FormatDim3Range(Stream &strm, const char *prefix,
-                            const Dim3 &min_dim, const Dim3 &max_dim) {
-  strm.Printf("%s(", prefix);
-  FormatDimRange(strm, "x", min_dim.x, max_dim.x);
-  strm.PutChar(' ');
-  FormatDimRange(strm, "y", min_dim.y, max_dim.y);
-  strm.PutChar(' ');
-  FormatDimRange(strm, "z", min_dim.z, max_dim.z);
-  strm.PutChar(')');
-}
+  void Insert(int v) {
+    min_v = std::min(min_v, v);
+    max_v = std::max(max_v, v);
+    values.insert(v);
+  }
+  bool IsEmpty() const { return values.empty(); }
+  bool IsSingle() const { return values.size() == 1; }
+  bool IsContiguous() const {
+    return !IsEmpty() &&
+           static_cast<size_t>(max_v - min_v + 1) == values.size();
+  }
+};
 
-/// Represents a group of consecutive threads sharing the same PC and stop
-/// reason.
-struct ConsecutiveThreadGroup {
+/// How a group's representative location was identified.
+///
+/// Resolution order: LineAndFunction first (most specific), then FunctionOnly
+/// (e.g. function missing line info), then PCOnly (no symbol resolution at
+/// all). Each tier produces a distinct group key and a distinct rendering.
+/// FilteredOut is a synthetic tier used to collapse all threads dropped by a
+/// list-time filter (e.g. --exceptions) into a single summary entry that is
+/// rendered alongside the real groups.
+///
+/// Empty and Tombstone are sentinels reserved for llvm::DenseMapInfo<GroupKey>
+/// and are never produced by BuildGroupKey.
+enum class GroupKind {
+  LineAndFunction,
+  FunctionOnly,
+  PCOnly,
+  FilteredOut,
+  Empty,
+  Tombstone,
+};
+
+/// Identity of an aggregated thread group. Only fields relevant to the kind
+/// are populated; the rest stay defaulted and are ignored by equality and
+/// hashing (e.g. `pc` is meaningful only for PCOnly groups).
+struct GroupKey {
+  GroupKind kind = GroupKind::PCOnly;
+  std::string file;
+  uint32_t line = 0;
+  std::string function;
   lldb::addr_t pc = LLDB_INVALID_ADDRESS;
   lldb::StopReason stop_reason = lldb::eStopReasonInvalid;
   uint64_t stop_value = 0;
-  std::vector<CUDAThreadCoord> coords;
-  ThreadSP representative_thread;
+
+  bool operator==(const GroupKey &other) const {
+    if (kind != other.kind)
+      return false;
+    // Sentinel-like kinds (FilteredOut, plus DenseMap Empty/Tombstone)
+    // carry no additional identity beyond the kind itself.
+    if (kind == GroupKind::FilteredOut || kind == GroupKind::Empty ||
+        kind == GroupKind::Tombstone)
+      return true;
+    if (stop_reason != other.stop_reason || stop_value != other.stop_value)
+      return false;
+    switch (kind) {
+    case GroupKind::LineAndFunction:
+      return line == other.line && file == other.file &&
+             function == other.function;
+    case GroupKind::FunctionOnly:
+      return function == other.function;
+    case GroupKind::PCOnly:
+      return pc == other.pc;
+    case GroupKind::FilteredOut:
+    case GroupKind::Empty:
+    case GroupKind::Tombstone:
+      llvm_unreachable("sentinel kinds handled above");
+    }
+    return false;
+  }
 };
 
-size_t PlatformNVGPU::GetGPUThreadStatus(Process &process, Stream &strm,
-                                         bool only_threads_with_stop_reason) {
-  // Build groups of consecutive threads that share the same PC.
-  // We only coalesce threads that are adjacent in the thread list.
-  std::vector<ConsecutiveThreadGroup> groups;
+struct GroupKeyHash {
+  size_t operator()(const GroupKey &k) const {
+    switch (k.kind) {
+    case GroupKind::LineAndFunction:
+      return llvm::hash_combine(static_cast<int>(k.kind),
+                                llvm::StringRef(k.file), k.line,
+                                llvm::StringRef(k.function),
+                                static_cast<int>(k.stop_reason), k.stop_value);
+    case GroupKind::FunctionOnly:
+      return llvm::hash_combine(static_cast<int>(k.kind),
+                                llvm::StringRef(k.function),
+                                static_cast<int>(k.stop_reason), k.stop_value);
+    case GroupKind::PCOnly:
+      return llvm::hash_combine(static_cast<int>(k.kind), k.pc,
+                                static_cast<int>(k.stop_reason), k.stop_value);
+    case GroupKind::FilteredOut:
+    case GroupKind::Empty:
+    case GroupKind::Tombstone:
+      return llvm::hash_value(static_cast<int>(k.kind));
+    }
+    return 0;
+  }
+};
 
-  // Collect all thread IDs first to avoid holding the lock while iterating.
-  std::vector<lldb::tid_t> thread_ids;
+namespace llvm {
+template <> struct DenseMapInfo<::GroupKey> {
+  static ::GroupKey getEmptyKey() {
+    ::GroupKey k;
+    k.kind = ::GroupKind::Empty;
+    return k;
+  }
+  static ::GroupKey getTombstoneKey() {
+    ::GroupKey k;
+    k.kind = ::GroupKind::Tombstone;
+    return k;
+  }
+  static unsigned getHashValue(const ::GroupKey &k) {
+    return static_cast<unsigned>(::GroupKeyHash{}(k));
+  }
+  static bool isEqual(const ::GroupKey &lhs, const ::GroupKey &rhs) {
+    return lhs == rhs;
+  }
+};
+} // namespace llvm
+
+/// Aggregated representation of all threads sharing one GroupKey.
+struct ThreadGroup {
+  GroupKey key;
+  llvm::SmallVector<CUDAThreadCoord, 32> coords;
+  ThreadSP representative_thread;
+  /// SymbolContext that produced the group key for the representative thread,
+  /// kept around so the renderer can pull display fields (module name, frame
+  /// address) without re-resolving.
+  SymbolContext representative_sc;
+  /// Address used to resolve `representative_sc`. May be the per-warp errorPC.
+  lldb::addr_t representative_address = LLDB_INVALID_ADDRESS;
+  /// True when grouping is anchored on errorPC rather than the per-thread PC.
+  bool used_error_pc = false;
+  /// True when the user-selected thread belongs to this group; used to
+  /// prefix the rendered row with "*".
+  bool contains_selected = false;
+  DimSet bx, by, bz, tx, ty, tz;
+};
+
+/// Format a DimSet as either name=v, name=[min...max], or name=*.
+static void FormatDimSet(Stream &strm, const char *name, const DimSet &dim) {
+  if (dim.IsEmpty()) {
+    strm.Printf("%s=*", name);
+    return;
+  }
+  if (dim.IsSingle()) {
+    strm.Printf("%s=%d", name, dim.min_v);
+    return;
+  }
+  if (dim.IsContiguous()) {
+    strm.Printf("%s=[%d...%d]", name, dim.min_v, dim.max_v);
+    return;
+  }
+  strm.Printf("%s=*", name);
+}
+
+/// Format an aggregated blockIdx/threadIdx triple using DimSet wildcards.
+static void FormatDim3Set(Stream &strm, const char *prefix, const DimSet &x,
+                          const DimSet &y, const DimSet &z) {
+  strm.Printf("%s(", prefix);
+  FormatDimSet(strm, "x", x);
+  strm.PutChar(' ');
+  FormatDimSet(strm, "y", y);
+  strm.PutChar(' ');
+  FormatDimSet(strm, "z", z);
+  strm.PutChar(')');
+}
+
+/// Snapshot of the inputs we need to build groups, captured up front so we do
+/// not hold the thread-list lock while iterating frames and symbols.
+struct ThreadSnapshot {
+  ThreadSP thread_sp;
+  CUDAThreadCoord coord;
+  lldb::addr_t pc = LLDB_INVALID_ADDRESS;
+  /// Per-warp errorPC reported by the NVIDIA debugger backend, or 0 when no
+  /// valid errorPC is available. When a warp hits an exception, the per-lane
+  /// PC may have advanced past the actual fault site due to instruction
+  /// slippage; errorPC pinpoints the real fault address and lets us aggregate
+  /// threads from different warps that hit the same fault.
+  lldb::addr_t error_pc = 0;
+  lldb::StopReason stop_reason = lldb::eStopReasonInvalid;
+  uint64_t stop_value = 0;
+};
+
+/// Accumulate one snapshot's coordinates into a group: per-dim DimSets and
+/// the coords vector. The caller is responsible for setting `representative_*`
+/// fields on first insertion.
+static void AccumulateSnapshotIntoGroup(ThreadGroup &group,
+                                        const ThreadSnapshot &snap) {
+  group.coords.push_back(snap.coord);
+  group.bx.Insert(snap.coord.block_idx.x);
+  group.by.Insert(snap.coord.block_idx.y);
+  group.bz.Insert(snap.coord.block_idx.z);
+  group.tx.Insert(snap.coord.thread_idx.x);
+  group.ty.Insert(snap.coord.thread_idx.y);
+  group.tz.Insert(snap.coord.thread_idx.z);
+}
+
+/// Collect per-thread snapshots needed to build groups. Threads without CUDA
+/// coordinates, register contexts, or PCs are dropped here so neither group
+/// builder has to special-case them. List-time filters such as
+/// --exceptions are applied later in the group-building phase by routing
+/// non-matching threads to a synthetic FilteredOut group.
+static llvm::SmallVector<ThreadSnapshot, 64>
+CollectThreadSnapshots(Process &process, bool only_threads_with_stop_reason) {
+  // Snapshot the list of threads under the list lock, then iterate them
+  // outside of it. Looking each thread up by ID inside the loop would be
+  // O(N) per call (linear scan + mutex op + UpdateThreadListIfNeeded check),
+  // turning the whole collection step quadratic for tens of thousands of
+  // GPU lanes.
+  llvm::SmallVector<ThreadSP, 64> threads;
   {
     std::lock_guard<std::recursive_mutex> guard(
         process.GetThreadList().GetMutex());
     ThreadList &thread_list = process.GetThreadList();
     uint32_t num_threads = thread_list.GetSize();
-    thread_ids.reserve(num_threads);
+    threads.reserve(num_threads);
     for (uint32_t i = 0; i < num_threads; ++i)
-      thread_ids.push_back(thread_list.GetThreadAtIndex(i)->GetID());
+      threads.push_back(thread_list.GetThreadAtIndex(i));
   }
 
-  // Get selected thread ID for marking.
-  lldb::tid_t selected_tid = LLDB_INVALID_THREAD_ID;
-  ThreadSP selected_thread = process.GetThreadList().GetSelectedThread();
-  if (selected_thread)
-    selected_tid = selected_thread->GetID();
+  // The errorPC RegisterInfo is identical across every NVGPU thread because
+  // they all share the SASS register layout. Look it up once on the first
+  // valid register context and reuse the pointer for every subsequent
+  // thread instead of a string scan per thread. nullopt = not yet looked up;
+  // a populated nullptr = looked up but the register isn't exposed.
+  std::optional<const RegisterInfo *> err_pc_info;
 
-  // Process each thread, grouping consecutive threads with the same PC.
-  for (lldb::tid_t tid : thread_ids) {
-    ThreadSP thread_sp = process.GetThreadList().FindThreadByID(tid);
+  llvm::SmallVector<ThreadSnapshot, 64> snapshots;
+  snapshots.reserve(threads.size());
+
+  for (const ThreadSP &thread_sp : threads) {
     if (!thread_sp)
       continue;
 
-    // Filter by stop reason if requested.
-    if (only_threads_with_stop_reason) {
-      StopInfoSP stop_info_sp = thread_sp->GetStopInfo();
-      if (!stop_info_sp || !stop_info_sp->ShouldShow())
-        continue;
-    }
+    StopInfoSP stop_info_sp = thread_sp->GetStopInfo();
+    if (only_threads_with_stop_reason &&
+        (!stop_info_sp || !stop_info_sp->ShouldShow()))
+      continue;
 
-    // Get the thread name and parse CUDA coordinates.
     const char *name = thread_sp->GetName();
     if (!name)
       continue;
@@ -744,10 +878,8 @@ size_t PlatformNVGPU::GetGPUThreadStatus(Process &process, Stream &strm,
     CUDAThreadCoord coord;
     if (!ParseCUDAThreadName(name, coord))
       continue;
+    coord.tid = thread_sp->GetID();
 
-    coord.tid = tid;
-
-    // Get the PC from the register context.
     RegisterContextSP reg_ctx_sp = thread_sp->GetRegisterContext();
     if (!reg_ctx_sp)
       continue;
@@ -756,118 +888,291 @@ size_t PlatformNVGPU::GetGPUThreadStatus(Process &process, Stream &strm,
     if (pc == LLDB_INVALID_ADDRESS)
       continue;
 
-    lldb::StopReason stop_reason = lldb::eStopReasonInvalid;
-    uint64_t stop_value = 0;
-    StopInfoSP stop_info_sp = thread_sp->GetStopInfo();
-    if (stop_info_sp) {
-      stop_reason = stop_info_sp->GetStopReason();
-      stop_value = stop_info_sp->GetValue();
-    }
+    if (!err_pc_info)
+      err_pc_info = reg_ctx_sp->GetRegisterInfoByName("errorPC");
 
-    // Group consecutive threads that share the same PC and stop reason.
-    if (!groups.empty() && groups.back().pc == pc &&
-        groups.back().stop_reason == stop_reason &&
-        groups.back().stop_value == stop_value) {
-      groups.back().coords.push_back(coord);
-    } else {
-      ConsecutiveThreadGroup new_group;
-      new_group.pc = pc;
-      new_group.stop_reason = stop_reason;
-      new_group.stop_value = stop_value;
-      new_group.coords.push_back(coord);
-      new_group.representative_thread = thread_sp;
-      groups.push_back(std::move(new_group));
+    ThreadSnapshot snap;
+    snap.thread_sp = thread_sp;
+    snap.coord = coord;
+    snap.pc = pc;
+    if (*err_pc_info) {
+      RegisterValue val;
+      if (reg_ctx_sp->ReadRegister(*err_pc_info, val))
+        snap.error_pc = val.GetAsUInt64(/*fail_value=*/0);
     }
+    if (stop_info_sp) {
+      snap.stop_reason = stop_info_sp->GetStopReason();
+      snap.stop_value = stop_info_sp->GetValue();
+    }
+    snapshots.push_back(std::move(snap));
+  }
+  return snapshots;
+}
+
+/// Resolution result for a thread's location: the SymbolContext we used and
+/// the address it was resolved from (errorPC when available, otherwise the
+/// thread's own PC).
+struct ResolvedLocation {
+  SymbolContext sc;
+  lldb::addr_t address = LLDB_INVALID_ADDRESS;
+  /// True when `address` is the per-warp errorPC instead of the per-thread PC.
+  bool used_error_pc = false;
+};
+
+/// Per-call cache mapping a load address to its resolved SymbolContext. Used
+/// to dedupe DWARF lookups across the (potentially tens of thousands of)
+/// threads that share a small set of distinct PCs / errorPCs.
+using LocationCache = llvm::DenseMap<lldb::addr_t, SymbolContext>;
+
+/// Resolve `pc` to a SymbolContext, consulting `cache` first. Empty
+/// SymbolContext on failure (matches existing behaviour).
+static SymbolContext ResolveSymbolContextCached(lldb::addr_t pc, Target &target,
+                                                LocationCache &cache) {
+  auto it = cache.find(pc);
+  if (it != cache.end())
+    return it->second;
+  SymbolContext sc;
+  Address addr;
+  if (addr.SetLoadAddress(pc, &target))
+    addr.CalculateSymbolContext(&sc, eSymbolContextEverything);
+  cache[pc] = sc;
+  return sc;
+}
+
+/// Resolve a thread's location, preferring the per-warp errorPC when
+/// available so that warps suffering from exception-induced PC slippage all
+/// resolve to the same fault site. SymbolContext lookups are deduped across
+/// threads via `cache`.
+static ResolvedLocation ResolveLocation(const ThreadSnapshot &snap,
+                                        Target &target, LocationCache &cache) {
+  ResolvedLocation out;
+  if (snap.error_pc != 0) {
+    out.sc = ResolveSymbolContextCached(snap.error_pc, target, cache);
+    out.address = snap.error_pc;
+    out.used_error_pc = true;
+    return out;
+  }
+  out.sc = ResolveSymbolContextCached(snap.pc, target, cache);
+  out.address = snap.pc;
+  return out;
+}
+
+/// Test whether a snapshot's stop reason matches a `--stop-reason` filter.
+/// An empty filter matches everything. The keywords `exception` and `signal`
+/// match the corresponding lldb::StopReason category. Otherwise the filter
+/// is interpreted as a case-insensitive substring of the stop reason's
+/// description (e.g. `SIGTRAP` matches `signal SIGTRAP`, `MMU` matches
+/// `Warp MMU Fault`).
+static bool MatchesStopReasonFilter(const ThreadSnapshot &snap,
+                                    llvm::StringRef filter) {
+  if (filter.empty())
+    return true;
+  if (filter.equals_insensitive("exception"))
+    return snap.stop_reason == lldb::eStopReasonException;
+  if (filter.equals_insensitive("signal"))
+    return snap.stop_reason == lldb::eStopReasonSignal;
+  if (StopInfoSP stop_info = snap.thread_sp->GetStopInfo()) {
+    if (const char *desc = stop_info->GetDescription())
+      return llvm::StringRef(desc).contains_insensitive(filter);
+  }
+  return false;
+}
+
+/// Pick the most specific tier (line+function > function-only > pc-only) that
+/// the resolved location supports and produce the corresponding GroupKey.
+/// When `stop_reason_filter` is non-empty and the snapshot does not match it,
+/// returns a synthetic FilteredOut key so all such threads aggregate into a
+/// single summary group.
+static GroupKey BuildGroupKey(const ThreadSnapshot &snap,
+                              const ResolvedLocation &loc,
+                              llvm::StringRef stop_reason_filter) {
+  GroupKey key;
+  if (!MatchesStopReasonFilter(snap, stop_reason_filter)) {
+    key.kind = GroupKind::FilteredOut;
+    return key;
   }
 
-  if (groups.empty())
+  key.stop_reason = snap.stop_reason;
+  key.stop_value = snap.stop_value;
+
+  ConstString fn = loc.sc.GetFunctionName(Mangled::ePreferDemangled);
+  llvm::StringRef fn_ref = fn.GetStringRef();
+
+  if (loc.sc.line_entry.IsValid() &&
+      loc.sc.line_entry.line != LLDB_INVALID_LINE_NUMBER && !fn_ref.empty()) {
+    key.kind = GroupKind::LineAndFunction;
+    key.file = loc.sc.line_entry.GetFile().GetPath(/*denormalize=*/false);
+    key.line = loc.sc.line_entry.line;
+    key.function = fn_ref.str();
+    return key;
+  }
+
+  if (!fn_ref.empty()) {
+    key.kind = GroupKind::FunctionOnly;
+    key.function = fn_ref.str();
+    return key;
+  }
+
+  key.kind = GroupKind::PCOnly;
+  key.pc = loc.address;
+  return key;
+}
+
+/// Render one aggregated group: count, coordinates with wildcards, stop
+/// reason on the first line, then a single indented location line whose
+/// contents depend on the group's tier.
+static void RenderAggregatedGroup(Stream &strm, const ThreadGroup &group) {
+  strm.Indent();
+  strm.Printf("%c %zu thread(s)", group.contains_selected ? '*' : ' ',
+              group.coords.size());
+
+  // For PC-only groups (no function name was resolvable), keep an
+  // "at pc=0x..." prefix so users can still navigate to the address. When the
+  // group was anchored on the per-warp errorPC (NVIDIA exception), label it
+  // as such so it is not confused with the per-thread PC.
+  if (group.key.kind == GroupKind::PCOnly) {
+    strm.Printf(" at %s=0x%llx", group.used_error_pc ? "errorPC" : "pc",
+                static_cast<unsigned long long>(group.key.pc));
+  }
+  strm.PutCString(": ");
+
+  FormatDim3Set(strm, "blockIdx", group.bx, group.by, group.bz);
+  strm.PutChar(' ');
+  FormatDim3Set(strm, "threadIdx", group.tx, group.ty, group.tz);
+
+  if (group.key.kind == GroupKind::FilteredOut) {
+    strm.PutCString(", hidden by --stop-reason filter");
+    strm.EOL();
+    return;
+  }
+
+  if (group.key.stop_reason != lldb::eStopReasonInvalid) {
+    if (StopInfoSP stop_info = group.representative_thread->GetStopInfo())
+      strm.Printf(", stop reason = %s", stop_info->GetDescription());
+  }
+  strm.EOL();
+
+  strm.IndentMore();
+  strm.IndentMore();
+  strm.Indent();
+
+  const SymbolContext &sc = group.representative_sc;
+  ConstString module_name;
+  if (sc.module_sp)
+    module_name = sc.module_sp->GetFileSpec().GetFilename();
+
+  switch (group.key.kind) {
+  case GroupKind::LineAndFunction:
+    if (module_name)
+      strm.Printf("%s`", module_name.GetCString());
+    strm.Printf("%s at %s:%u", group.key.function.c_str(),
+                group.key.file.c_str(), group.key.line);
+    break;
+  case GroupKind::FunctionOnly:
+    if (module_name)
+      strm.Printf("%s`", module_name.GetCString());
+    strm.PutCString(group.key.function);
+    break;
+  case GroupKind::FilteredOut:
+  case GroupKind::Empty:
+  case GroupKind::Tombstone:
+    llvm_unreachable("sentinel kinds handled above or never rendered");
+  case GroupKind::PCOnly: {
+    // sc.target_sp is not populated by Address::CalculateSymbolContext, so
+    // pull the target from the representative thread directly.
+    Target &target = group.representative_thread->GetProcess()->GetTarget();
+    Address resolved_addr;
+    resolved_addr.SetLoadAddress(group.representative_address, &target);
+    strm.Printf("0x%0*" PRIx64 " ",
+                target.GetArchitecture().GetAddressByteSize() * 2,
+                static_cast<uint64_t>(group.representative_address));
+    StackFrameSP frame_sp =
+        group.representative_thread->GetStackFrameAtIndex(0);
+    ExecutionContext exe_ctx(frame_sp);
+    sc.DumpStopContext(&strm, exe_ctx.GetBestExecutionContextScope(),
+                       resolved_addr,
+                       /*show_fullpaths=*/false,
+                       /*show_module=*/true, /*show_inlined_frames=*/true,
+                       /*show_function_arguments=*/false,
+                       /*show_function_name=*/true);
+    break;
+  }
+  }
+  strm.EOL();
+  strm.IndentLess();
+  strm.IndentLess();
+}
+
+/// Build aggregated groups using the most specific available identity per
+/// thread, then render them in first-seen order. The FilteredOut summary
+/// group (when present) is moved to the end of the list so the summary line
+/// always trails the real entries.
+static size_t RenderAggregated(Process &process, Stream &strm,
+                               bool only_threads_with_stop_reason,
+                               llvm::StringRef stop_reason_filter) {
+  llvm::SmallVector<ThreadSnapshot, 64> snapshots =
+      CollectThreadSnapshots(process, only_threads_with_stop_reason);
+  if (snapshots.empty())
     return 0;
 
-  // Print the process status first.
-  process.GetStatus(strm);
+  lldb::tid_t selected_tid = LLDB_INVALID_THREAD_ID;
+  if (ThreadSP selected_thread = process.GetThreadList().GetSelectedThread())
+    selected_tid = selected_thread->GetID();
 
-  // Print each group of consecutive threads.
-  size_t groups_printed = 0;
-  for (const auto &group : groups) {
-    // Compute the range covered by all threads in this group.
-    CUDAThreadRange range;
-    for (const auto &coord : group.coords)
-      range.AddCoord(coord);
+  // Map each GroupKey to an index into `groups`. Insertion order in `groups`
+  // gives us deterministic output; the map is only used for O(1) lookup of
+  // an existing group when a snapshot's key matches.
+  llvm::DenseMap<GroupKey, size_t> key_to_index;
+  std::vector<ThreadGroup> groups;
 
-    // Check if this group contains the selected thread.
-    bool is_selected = false;
-    if (selected_tid != LLDB_INVALID_THREAD_ID) {
-      for (const auto &coord : group.coords) {
-        if (coord.tid == selected_tid) {
-          is_selected = true;
-          break;
-        }
-      }
+  Target &target = process.GetTarget();
+  LocationCache location_cache;
+  for (const ThreadSnapshot &snap : snapshots) {
+    ResolvedLocation loc = ResolveLocation(snap, target, location_cache);
+    GroupKey key = BuildGroupKey(snap, loc, stop_reason_filter);
+    auto [it, inserted] =
+        key_to_index.try_emplace(std::move(key), groups.size());
+    if (inserted) {
+      ThreadGroup g;
+      g.key = it->first;
+      g.representative_thread = snap.thread_sp;
+      g.representative_sc = loc.sc;
+      g.representative_address = loc.address;
+      g.used_error_pc = loc.used_error_pc;
+      groups.push_back(std::move(g));
     }
-
-    // Add spacing between thread entries for better readability.
-    if (groups_printed > 0)
-      strm.EOL();
-
-    strm.Indent();
-    strm.Printf("%c ", is_selected ? '*' : ' ');
-
-    // Print coalesced thread info.
-    strm.Printf("%zu thread(s) at pc=0x%llx: ", range.count,
-                static_cast<unsigned long long>(group.pc));
-    FormatDim3Range(strm, "blockIdx", range.block_min, range.block_max);
-    strm.PutChar(' ');
-    FormatDim3Range(strm, "threadIdx", range.thread_min, range.thread_max);
-    if (group.stop_reason != lldb::eStopReasonInvalid) {
-      StopInfoSP stop_info =
-          group.representative_thread->GetStopInfo();
-      if (stop_info)
-        strm.Printf(", stop reason = %s", stop_info->GetDescription());
-    }
-    strm.EOL();
-
-    // Print the frame info from the representative thread.
-    // We show only the function name without arguments or source context
-    // since all coalesced threads share the same location.
-    ThreadSP thread_sp = group.representative_thread;
-    if (thread_sp) {
-      StackFrameSP frame_sp = thread_sp->GetStackFrameAtIndex(0);
-      if (frame_sp) {
-        strm.IndentMore();
-        strm.IndentMore();
-        strm.Indent();
-
-        ExecutionContext exe_ctx(frame_sp);
-        Target *target = exe_ctx.GetTargetPtr();
-        Address frame_addr = frame_sp->GetFrameCodeAddress();
-
-        // Print frame address.
-        strm.Printf("0x%0*" PRIx64 " ",
-                    target ? (target->GetArchitecture().GetAddressByteSize() * 2)
-                           : 16,
-                    frame_addr.GetLoadAddress(target));
-
-        // Get symbol context and dump without function arguments or source.
-        SymbolContext sc = frame_sp->GetSymbolContext(eSymbolContextEverything);
-        const bool show_fullpaths = false;
-        const bool show_module = true;
-        const bool show_inlined_frames = true;
-        const bool show_function_arguments = false;
-        const bool show_function_name = true;
-        sc.DumpStopContext(&strm, exe_ctx.GetBestExecutionContextScope(),
-                           frame_addr, show_fullpaths, show_module,
-                           show_inlined_frames, show_function_arguments,
-                           show_function_name);
-        strm.EOL();
-        strm.IndentLess();
-        strm.IndentLess();
-      }
-    }
-
-    ++groups_printed;
+    ThreadGroup &group = groups[it->second];
+    AccumulateSnapshotIntoGroup(group, snap);
+    if (selected_tid != LLDB_INVALID_THREAD_ID &&
+        snap.coord.tid == selected_tid)
+      group.contains_selected = true;
   }
 
-  return groups_printed;
+  // Move the FilteredOut summary group, if any, to the end of the list so the
+  // summary line always trails the real entries. Relative order of the real
+  // groups is preserved.
+  auto filtered_it =
+      std::find_if(groups.begin(), groups.end(), [](const ThreadGroup &g) {
+        return g.key.kind == GroupKind::FilteredOut;
+      });
+  if (filtered_it != groups.end())
+    std::rotate(filtered_it, filtered_it + 1, groups.end());
+
+  process.GetStatus(strm);
+
+  for (size_t i = 0; i < groups.size(); ++i) {
+    if (i > 0)
+      strm.EOL();
+    RenderAggregatedGroup(strm, groups[i]);
+  }
+  return groups.size();
+}
+
+size_t PlatformNVGPU::GetGPUThreadStatus(Process &process, Stream &strm,
+                                         bool only_threads_with_stop_reason,
+                                         llvm::StringRef stop_reason_filter) {
+  return RenderAggregated(process, strm, only_threads_with_stop_reason,
+                          stop_reason_filter);
 }
 
 bool PlatformNVGPU::ParseGPUThreadName(llvm::StringRef name, GPUDim3 &block_idx,

--- a/lldb/source/Plugins/Platform/NVGPU/PlatformNVGPU.h
+++ b/lldb/source/Plugins/Platform/NVGPU/PlatformNVGPU.h
@@ -83,7 +83,8 @@ public:
                           Target &target) override;
 
   size_t GetGPUThreadStatus(Process &process, Stream &strm,
-                            bool only_threads_with_stop_reason) override;
+                            bool only_threads_with_stop_reason,
+                            llvm::StringRef stop_reason_filter = {}) override;
 
   lldb::ThreadSP FindGPUThread(Process &process, const GPUDim3 &block_idx,
                                const GPUDim3 &thread_idx) override;

--- a/lldb/test/API/gpu/nvidia/assert/TestNVGPUAssert.py
+++ b/lldb/test/API/gpu/nvidia/assert/TestNVGPUAssert.py
@@ -19,12 +19,12 @@ class TestNVGPUAssert(NVGPUTestCaseBase):
         self.continue_cpu_and_wait_for_gpu_to_stop()
 
         self.assertEqual(self.gpu_process.state, lldb.eStateStopped)
-        self.assertIn("CUDA Exception(12): Warp - Assert", str(self.gpu_process.thread[0]))
+        self.assertIn("CUDA Exception(12): Warp Assert", str(self.gpu_process.thread[0]))
 
         frame = self.gpu_process.thread[0].frame[0]
 
         # We don't expect to see an errorpc set
-        self.assertNotIn("CUDA Exception(12): Warp - Assert at 0x", str(self.gpu_process.thread[0]))
+        self.assertNotIn("CUDA Exception(12): Warp Assert at 0x", str(self.gpu_process.thread[0]))
         errorpc = frame.FindRegister("errorpc").GetValueAsAddress()
         self.assertEqual(errorpc, lldb.LLDB_INVALID_ADDRESS)
 

--- a/lldb/test/API/gpu/nvidia/breakpoints/TestNVGPUBreakpoints.py
+++ b/lldb/test/API/gpu/nvidia/breakpoints/TestNVGPUBreakpoints.py
@@ -30,8 +30,12 @@ class TestNVGPUBreakpoints(NVGPUTestCaseBase):
 
         self.select_gpu()
 
+        # Use `thread list -v` to opt out of the GPU-specific aggregation so
+        # each (blockIdx, threadIdx) row is rendered separately. This lets us
+        # verify that the specific (0,0,0) thread in each of the four blocks
+        # hit the breakpoint.
         self.expect(
-            "thread list",
+            "thread list -v",
             substrs=[
                 f"at {source}:{gpu_bp_line}, name = 'blockIdx(x=0 y=0 z=0) threadIdx(x=0 y=0 z=0)', stop reason = breakpoint 1.1",
                 f"at {source}:{gpu_bp_line}, name = 'blockIdx(x=1 y=0 z=0) threadIdx(x=0 y=0 z=0)', stop reason = breakpoint 1.1",
@@ -44,7 +48,7 @@ class TestNVGPUBreakpoints(NVGPUTestCaseBase):
         self.select_gpu()
         self.gpu_process.Continue()
         self.expect(
-            "thread list",
+            "thread list -v",
             substrs=[
                 f"at {source}:{gpu_bp_line_2}, name = 'blockIdx(x=0 y=0 z=0) threadIdx(x=0 y=0 z=0)', stop reason = breakpoint 2.1",
                 f"at {source}:{gpu_bp_line_2}, name = 'blockIdx(x=1 y=0 z=0) threadIdx(x=0 y=0 z=0)', stop reason = breakpoint 2.1",

--- a/lldb/test/API/gpu/nvidia/disass/TestNVGPUDisass.py
+++ b/lldb/test/API/gpu/nvidia/disass/TestNVGPUDisass.py
@@ -42,7 +42,7 @@ class TestNVGPUDisass(NVGPUTestCaseBase):
         self.continue_cpu_and_wait_for_gpu_to_stop()
 
         self.assertEqual(self.gpu_process.state, lldb.eStateStopped)
-        self.assertIn("CUDA Exception(12): Warp - Assert", str(self.gpu_process.thread[0]))
+        self.assertIn("CUDA Exception(12): Warp Assert", str(self.gpu_process.thread[0]))
 
         # Now let's test that the disass can print at least one entry
         self.expect("disassemble", patterns=[".*cuda_elf.*\\.cubin`.*:.*"])

--- a/lldb/test/API/gpu/nvidia/registers/TestNVGPURegisters.py
+++ b/lldb/test/API/gpu/nvidia/registers/TestNVGPURegisters.py
@@ -26,7 +26,7 @@ class TestNVGPURegisters(NVGPUTestCaseBase):
 
         self.assertEqual(self.gpu_process.state, lldb.eStateStopped)
         some_thread_with_exception = self.find_thread_by_stop_reason(lldb.eStopReasonException)
-        self.assertIn("CUDA Exception(6): Warp - Misaligned address at 0x", str(some_thread_with_exception))
+        self.assertIn("CUDA Exception(6): Warp Misaligned Address at 0x", str(some_thread_with_exception))
 
         frame = some_thread_with_exception.frame[0]
 

--- a/lldb/test/API/gpu/nvidia/threads/TestNVGPUThreads.py
+++ b/lldb/test/API/gpu/nvidia/threads/TestNVGPUThreads.py
@@ -62,11 +62,11 @@ class TestNVGPUThreads(NVGPUTestCaseBase):
 
         # Verbose mode opts out of GPU-specific aggregation and renders one
         # row per thread, like `thread list` on a CPU target. Each row uses
-        # the standard "thread #N: tid = ..." prefix and exposes the per-
-        # thread PC.
+        # the standard `thread #N: tid = ...` prefix and embeds the CUDA
+        # coordinates in the thread name.
         self.expect(
             "thread list -v",
-            substrs=["thread #", "pc =", "name = 'blockIdx"],
+            substrs=["thread #", "tid = 0x", "name = 'blockIdx"],
             matching=True,
         )
         self.expect("thread list -v", substrs=["thread(s):"], matching=False)

--- a/lldb/test/API/gpu/nvidia/threads/TestNVGPUThreads.py
+++ b/lldb/test/API/gpu/nvidia/threads/TestNVGPUThreads.py
@@ -30,3 +30,75 @@ class TestNVGPUThreads(NVGPUTestCaseBase):
 
         thread_without_exception = self.find_thread_by_name("threadIdx(x=511 y=0 z=0)")
         self.assertEqual(thread_without_exception.GetStopReason(), lldb.eStopReasonNone)
+
+    def test_thread_list_aggregation(self):
+        """Test that `thread list` aggregates GPU threads by source line and that
+        `-v` falls back to the legacy per-PC layout."""
+        self.killCPUOnTeardown()
+
+        self.build()
+        source = "threads.cu"
+        cpu_bp_line: int = line_number(source, "// before kernel launch")
+        exit_bp_line: int = line_number(source, "// breakpoint before exit")
+
+        lldbutil.run_to_line_breakpoint(self, lldb.SBFileSpec(source), cpu_bp_line)
+        self.cpu_target.BreakpointCreateByLocation(lldb.SBFileSpec(source), exit_bp_line)
+
+        self.continue_cpu_and_wait_for_gpu_to_stop()
+        self.select_gpu()
+
+        # Default (aggregated) mode: groups are summarized by source line, the
+        # raw "pc=0x" prefix is suppressed in favor of "module`function at
+        # file:line", and large thread counts are visible in the summary line.
+        self.expect(
+            "thread list",
+            substrs=[
+                "thread(s):",
+                f"at {source}:",
+            ],
+            matching=True,
+        )
+        self.expect("thread list", substrs=["pc=0x"], matching=False)
+
+        # Verbose mode opts out of GPU-specific aggregation and renders one
+        # row per thread, like `thread list` on a CPU target. Each row uses
+        # the standard "thread #N: tid = ..." prefix and exposes the per-
+        # thread PC.
+        self.expect(
+            "thread list -v",
+            substrs=["thread #", "pc =", "name = 'blockIdx"],
+            matching=True,
+        )
+        self.expect("thread list -v", substrs=["thread(s):"], matching=False)
+
+        # --stop-reason exception (default rendering): filters down to threads
+        # whose stop reason is a CUDA exception. The thread that dereferenced
+        # 0x03 must still be there; threads from non-faulting warps are folded
+        # into a trailing summary row.
+        self.expect(
+            "thread list -s exception",
+            substrs=["thread(s):", "hidden by --stop-reason filter"],
+            matching=True,
+        )
+        self.expect(
+            "thread list -s exception",
+            substrs=["threadIdx(x=511 y=0 z=0), stop reason"],
+            matching=False,
+        )
+
+        # --stop-reason SIGTRAP: substring match against the description, used
+        # here to limit the output to the SIGTRAP-stopped threads in the
+        # warp.
+        self.expect(
+            "thread list -s SIGTRAP",
+            substrs=["thread(s):"],
+            matching=True,
+        )
+
+        # Combining -v and --stop-reason: per-thread rendering, filtered to
+        # threads matching the filter expression.
+        self.expect(
+            "thread list -v -s exception",
+            substrs=["thread #"],
+            matching=True,
+        )

--- a/lldb/test/API/gpu/nvidia/threads/TestNVGPUThreads.py
+++ b/lldb/test/API/gpu/nvidia/threads/TestNVGPUThreads.py
@@ -1,3 +1,5 @@
+import re
+
 import lldb
 from lldbsuite.test import lldbutil
 from lldbsuite.test.lldbtest import line_number
@@ -101,4 +103,146 @@ class TestNVGPUThreads(NVGPUTestCaseBase):
             "thread list -v -s exception",
             substrs=["thread #"],
             matching=True,
+        )
+
+    def test_thread_list_aggregation_row_format(self):
+        """Pin down the exact format of an aggregated `thread list` row on a
+        GPU target. This complements `test_thread_list_aggregation` (which
+        covers high-level switches: aggregation vs `-v`, `--stop-reason`
+        filtering, the trailing summary row) by verifying the precise
+        rendering produced by PlatformNVGPU::GetGPUThreadStatus.
+
+        Each group is rendered as two lines:
+
+            <prefix> N thread(s): blockIdx(...) threadIdx(...)[, stop reason = ...]
+                <cubin>`<function> at <basename>:<line>
+
+        where <prefix> is `*` for the group containing the selected thread
+        and a space otherwise, and the `, stop reason = ...` suffix is only
+        emitted for groups whose stop reason is valid and should be shown.
+
+        The kernel launches `<<<1, 512>>>`, so blockIdx is single-valued
+        in every dimension (exercises the `name=V` form of FormatDimSet)
+        and threadIdx.{y,z} are also single-valued. The on-device control
+        flow happens to produce all three threadIdx.x forms in the same
+        output, so this test exercises every FormatDimSet branch:
+
+          * single value `x=5`             -- the lone faulting thread,
+          * contiguous range `x=[32...511]` -- the threads still at the
+            store after the second `__syncthreads()`,
+          * wildcard `x=*`                  -- a warp where the surviving
+            lanes form a non-contiguous set after the divergent branch.
+        """
+        self.killCPUOnTeardown()
+
+        self.build()
+        source = "threads.cu"
+        cpu_bp_line: int = line_number(source, "// before kernel launch")
+        exit_bp_line: int = line_number(source, "// breakpoint before exit")
+
+        lldbutil.run_to_line_breakpoint(self, lldb.SBFileSpec(source), cpu_bp_line)
+        self.cpu_target.BreakpointCreateByLocation(lldb.SBFileSpec(source), exit_bp_line)
+
+        self.continue_cpu_and_wait_for_gpu_to_stop()
+        self.select_gpu()
+
+        # Capture the aggregated output once and run all assertions against
+        # it; re-running `thread list` per assertion would also re-resolve
+        # symbols on the GPU target and slow the test down for no gain.
+        self.runCmd("thread list")
+        aggregated = self.res.GetOutput()
+
+        # Header line schema. blockIdx is single-valued in every dimension
+        # because the kernel launches one block. threadIdx.x is one of the
+        # three FormatDimSet renderings (single value, contiguous range, or
+        # wildcard). threadIdx.{y,z} are always single-valued.
+        header_pattern = re.compile(
+            r"^[* ] \d+ thread\(s\): "
+            r"blockIdx\(x=0 y=0 z=0\) "
+            r"threadIdx\(x=(?:\d+|\[\d+\.\.\.\d+\]|\*) y=0 z=0\)"
+            r"(?:, stop reason = .+)?$",
+            re.MULTILINE,
+        )
+        header_matches = header_pattern.findall(aggregated)
+        self.assertGreater(
+            len(header_matches),
+            0,
+            "No header lines matched the aggregated row schema in:\n"
+            + aggregated,
+        )
+
+        # Exactly one row must be marked with `*` -- the group that owns the
+        # selected thread.
+        selected_marker_pattern = re.compile(
+            r"^\* \d+ thread\(s\): blockIdx\(", re.MULTILINE
+        )
+        self.assertEqual(
+            len(selected_marker_pattern.findall(aggregated)),
+            1,
+            "Expected exactly one `* N thread(s):` row in:\n" + aggregated,
+        )
+
+        # All three FormatDimSet branches must appear in this run.
+        self.assertRegex(
+            aggregated,
+            r"threadIdx\(x=\d+ y=0 z=0\)",
+            "Missing single-value threadIdx form",
+        )
+        self.assertRegex(
+            aggregated,
+            r"threadIdx\(x=\[\d+\.\.\.\d+\] y=0 z=0\)",
+            "Missing contiguous-range threadIdx form",
+        )
+        self.assertRegex(
+            aggregated,
+            r"threadIdx\(x=\* y=0 z=0\)",
+            "Missing wildcard threadIdx form",
+        )
+
+        # Location-line schema (LineAndFunction tier): module name,
+        # backtick, demangled function (which includes the parameter list
+        # for CUDA kernels), " at ", source basename (never a full path),
+        # colon, line number.
+        self.assertRegex(
+            aggregated,
+            r"`setAndCopyKernel\(.*\) at threads\.cu:\d+",
+            "Missing module`function-with-args at file:line location line",
+        )
+        # Defensive check: the basename rendering must not regress to
+        # printing the absolute path.
+        self.assertNotRegex(
+            aggregated,
+            r"at /.*/threads\.cu:",
+            "Location line should print only the basename of the source file",
+        )
+
+        # The faulting thread (tid 5 reading 0x03) must show up as its own
+        # group with a CUDA exception stop reason. This pins down the exact
+        # combination of single-value threadIdx + stop reason rendering.
+        self.assertRegex(
+            aggregated,
+            r"\d+ thread\(s\): blockIdx\(x=0 y=0 z=0\) "
+            r"threadIdx\(x=5 y=0 z=0\), "
+            r"stop reason = CUDA Exception",
+            "Did not find the expected faulting-thread group",
+        )
+
+        # Aggregation must actually collapse threads. The 512 lanes should
+        # be summarised in a handful of groups, never one row per lane.
+        self.assertLess(
+            aggregated.count(" thread(s): "),
+            16,
+            "Aggregated `thread list` produced too many rows for a 512-lane "
+            "kernel:\n" + aggregated,
+        )
+
+        # `thread list -v` is the per-thread fallback. Confirm it does emit
+        # one row per lane, so the aggregation above is a real reduction
+        # rather than a coincidence of having few threads to begin with.
+        self.runCmd("thread list -v")
+        verbose = self.res.GetOutput()
+        self.assertGreaterEqual(
+            verbose.count("thread #"),
+            512,
+            "`thread list -v` should render one row per lane; got:\n" + verbose,
         )


### PR DESCRIPTION
# `thread list` aggregation on NVIDIA GPU targets

## Summary

Replaces the per-PC consecutive grouping for `thread list` on NVIDIA GPU
targets with a global, source-line-keyed aggregation, and exposes two new
`thread list` switches that work uniformly on CPU and GPU targets. Brings
the per-thread fallback in line with standard LLDB formatting, and fills
out the test coverage around all of it.

| | |
| --- | --- |
| **Base** | `meta-nvidia` |
| **Branch** | `agontarek/meta-nvidia` |
| **Commits** | 3 |
| **Diffstat** | `11 files changed, 858 insertions(+), 209 deletions(-)` |

## Why

`thread list` on a CUDA kernel with thousands of lanes today prints one row
per per-PC group, which is unreadable and slow. Threads at the same source
line should collapse into a single row — especially when warps that hit the
same fault land on slightly different (slipped) PCs.

**Before** (any GPU `thread list` invocation, abbreviated):
```
* thread #1:   tid = 0x0001, ...   at threads.cu:18, name = 'blockIdx(x=0 y=0 z=0) threadIdx(x=0 y=0 z=0)'
  thread #2:   tid = 0x0002, ...   at threads.cu:18, name = 'blockIdx(x=0 y=0 z=0) threadIdx(x=1 y=0 z=0)'
  thread #3:   tid = 0x0003, ...   at threads.cu:18, name = 'blockIdx(x=0 y=0 z=0) threadIdx(x=2 y=0 z=0)'
  ...                              (≈509 more rows)
```

**After**:
```
(lldb) thread list
Process 1 stopped
* 31 thread(s): blockIdx(x=0 y=0 z=0) threadIdx(x=* y=0 z=0)
    cuda_elf_*.cubin`setAndCopyKernel(int*, int*) at threads.cu:16

  1 thread(s): blockIdx(x=0 y=0 z=0) threadIdx(x=5 y=0 z=0), stop reason = CUDA Exception(6): Warp Misaligned Address at 0x100052ab050
    cuda_elf_*.cubin`setAndCopyKernel(int*, int*) at threads.cu:12

  480 thread(s): blockIdx(x=0 y=0 z=0) threadIdx(x=[32...511] y=0 z=0)
    cuda_elf_*.cubin`setAndCopyKernel(int*, int*) at threads.cu:18
```

## Changes

Sequential, intended to be reviewed commit-by-commit.

### 1.  Aggregate `thread list` by source line on GPU targets

The substantive change. `PlatformNVGPU::GetGPUThreadStatus` is rewritten to:

- **Aggregate globally on `(file, line, function, stop reason)`** instead of
  the previous per-PC consecutive grouping. Threads at the same source
  location collapse into one row regardless of slipped PCs.
- **Prefer the per-warp `errorPC` over the per-thread PC** when reported by
  the NVIDIA backend, so warps that hit the same fault aggregate at the
  real fault site rather than at the slipped instruction.
- **Three fall-through resolution tiers** so we always render something
  sensible:
  1. `LineAndFunction` — `<module>`<function> at <file>:<line>`
  2. `FunctionOnly` — bare function name (e.g. `clock64` with no line info)
  3. `PCOnly` — `at pc=0x…` / `at errorPC=0x…`
- **Per-dimension coordinate rendering** as a single value (`x=5`), a
  contiguous range (`x=[0...31]`), or a wildcard (`x=*`) for non-contiguous
  sets.

New command-line surface (in `CommandObjectThread.cpp` / `Options.td`):

| Flag | Behavior |
| --- | --- |
| `-v` / `--verbose` | Opt out of GPU aggregation, render one row per lane (matches CPU `thread list`). No-op on CPU targets. |
| `-s` / `--stop-reason <expr>` | Filter by stop reason. Accepts the keywords `exception` and `signal`, a signal name (`SIGTRAP`), or any case-insensitive substring of the description (e.g. `MMU` matches `Warp MMU Fault`). Non-matching threads fold into a single trailing summary row. |

The `Platform::GetGPUThreadStatus` virtual gains a `stop_reason_filter`
parameter so the new flag plumbs through cleanly; the default platform
implementation ignores it.

Plumbing cleanup that fell out of the rewrite:

- Drops the legacy `ConsecutiveThreadGroup` path entirely.
- `std::unordered_map<GroupKey, …>` → `llvm::DenseMap` with a custom
  `DenseMapInfo<GroupKey>` specialisation.
- Removes a previously O(N²) `FindThreadByID` loop in the snapshot
  collection step.

### 2. Improve thread list output formatting

Two small polish items on top of #1:

- `thread list -v` now embeds CUDA coordinates directly in the thread name
  (`name = 'blockIdx(x=0 y=0 z=0) threadIdx(x=N y=0 z=0)'`), so per-lane
  rows look like standard LLDB thread rows.
- The aggregated location line now renders the **basename** of the source
  file (`at threads.cu:18`) instead of the absolute path. The full path is
  still kept inside `GroupKey` for equality, so two files with the same
  basename in different directories still hash to distinct groups.

### 3. Refactor GPU test cases for improved error handling and output validation

Three fixes to the test harness surfaced by running the full GPU suite
against the new code, plus one new test.

Fixes:

- **`killCPUOnTeardown` no longer crashes when targets are already
  destroyed.** Standard `TestBase.tearDown` deletes all targets *before*
  running registered hooks, so the previous
  `lambda: self.cpu_process.Kill()` saw `cpu_process is None` and raised
  `AttributeError`. Replaced with a guarded `kill_cpu` helper.
- **Sync CUDA exception assertion strings** with the form actually
  produced by `lldb/source/Utility/NVGPU/CUDAException.cpp`
  (`Warp Assert`, `Warp Misaligned Address`, …). The tests still expected
  the older hyphenated rendering and were failing on every CUDA-exception
  test.
- **`TestNVGPUBreakpoints`** was asserting the legacy per-thread
  `thread list` substrings, which the aggregator now collapses. Switched
  those assertions to `thread list -v` so the test still verifies "thread
  `(0, 0, 0)` of each of the four blocks hit the breakpoint" — this is
  the canonical migration pattern for callers that need the old layout.

New test:

- **`TestNVGPUThreads::test_thread_list_aggregation_row_format`** pins
  down the exact format emitted by `RenderAggregatedGroup`:
  - The header schema `* N thread(s): blockIdx(...) threadIdx(...)[, stop reason = ...]`.
  - Exactly one row carries the `*` selected-thread marker.
  - All three `FormatDimSet` branches appear in a single run: single
    value (`x=5`), contiguous range (`x=[32...511]`), and wildcard
    (`x=*`).
  - Location-line schema `` `<cubin>`<function-with-args> at <basename>:<line>` ``
    plus a negative check against absolute paths.
  - The faulting-thread group renders as a single-value coord + CUDA
    exception stop reason.
  - Aggregation actually reduces (< 16 rows for 512 lanes); `thread list -v`
    does emit ≥ 512 per-thread rows, so the reduction is real rather than
    an artifact of having few threads to begin with.

## Test plan

Full GPU API suite, RelWithDebInfo, x86_64 Linux:

```
$ ./build/bin/llvm-lit -v ./llvm-project/lldb/test/API/gpu/
...
PASS: lldb-api :: gpu/nvidia/cubins/TestNVGPUCubins.py
PASS: lldb-api :: gpu/nvidia/assert/TestNVGPUAssert.py
PASS: lldb-api :: gpu/nvidia/breakpoints/TestNVGPUBreakpoints.py
PASS: lldb-api :: gpu/nvidia/disass/TestNVGPUDisass.py
PASS: lldb-api :: gpu/nvidia/memory/TestNVGPUMemory.py
PASS: lldb-api :: gpu/nvidia/unwind/TestNVGPUUnwind.py
PASS: lldb-api :: gpu/nvidia/exit/TestNVGPUExit.py
PASS: lldb-api :: gpu/nvidia/registers/TestNVGPURegisters.py
PASS: lldb-api :: gpu/nvidia/threads/TestNVGPUThreads.py

  Unsupported: 16 (64.00%)   # AMD / mock-gpu tests, expected
  Passed     :  9 (36.00%)
```

Manual spot checks:

- `thread list`, `thread list -v`, `thread list -s exception`,
  `thread list -s SIGTRAP`, `thread list -v -s exception` against a
  512-lane kernel with one faulting thread.
- `thread list` on a kernel with `clock64` frames (no line info) to
  exercise the `FunctionOnly` tier.

## Backwards compatibility

- **CPU targets are unchanged.** The aggregation path only triggers for
  NVIDIA GPU targets via `Platform::GetGPUThreadStatus`; the new
  `-v` / `-s` flags are no-ops on CPU `thread list`.
- **Scripts that scraped the old per-PC GPU `thread list` output** should
  switch to `thread list -v` (the per-thread fallback). One in-tree test
  (`TestNVGPUBreakpoints`) was updated for exactly this reason and is
  the reference migration.
- **No API/ABI break** for out-of-tree platform plug-ins: the
  `Platform::GetGPUThreadStatus` virtual gains a new
  `stop_reason_filter` parameter with a sensible default, and the
  in-tree base implementation ignores it.
