### PR TITLE
[lldb] Expose AMDGPU core code-object build IDs

### DIFF
--- a/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
@@ -532,8 +532,11 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
               lib_info->file_offset.value_or(0),
               lib_info->file_size.value_or(0));
 
-    // Load the module
+    // Load the module.
     std::shared_ptr<DataBufferHeap> data_sp;
+    TargetSP cpu_target_sp = target.GetNativeTargetForGPU();
+    ProcessSP cpu_process_sp =
+        cpu_target_sp ? cpu_target_sp->GetProcessSP() : nullptr;
 
     // Read the object file from memory if available
     if (lib_info->native_memory_address.has_value() &&
@@ -544,9 +547,6 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
       LLDB_LOG(log, "Reading \"{0}\" from memory at {1:x}", lib_info->pathname,
                native_mem_addr);
 
-      TargetSP cpu_target_sp = target.GetNativeTargetForGPU();
-      ProcessSP cpu_process_sp =
-          cpu_target_sp ? cpu_target_sp->GetProcessSP() : nullptr;
       if (cpu_process_sp) {
         data_sp = std::make_shared<DataBufferHeap>(native_mem_size, 0);
         Status error;
@@ -566,6 +566,18 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
 
     // Create a module specification from the info we got.
     UUID uuid;
+    if (lib_info->uuid_str.has_value())
+      uuid.SetFromStringRef(*lib_info->uuid_str);
+    if (!uuid.IsValid() && lib_info->load_address.has_value()) {
+      if (std::shared_ptr<ProcessElfCore> cpu_core_process = GetCpuProcess())
+        uuid =
+            cpu_core_process->FindBuidIdInCoreMemory(*lib_info->load_address);
+    }
+
+    if (uuid.IsValid())
+      LLDB_LOG(log, "Code object \"{0}\" has build ID {1}", lib_info->pathname,
+               uuid.GetAsString(""));
+
     ModuleSpec module_spec(FileSpec(lib_info->pathname), uuid, data_sp);
 
     // Set file offset and size if available

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -286,8 +286,17 @@ void ProcessElfCore::UpdateBuildIdForNTFileEntries() {
   for (NT_FILE_Entry &entry : m_nt_file_entries) {
     UUID uuid = FindBuidIdInCoreMemory(entry.start);
     if (uuid.IsValid()) {
-      // Assert that either the path is not in the map or the UUID matches
-      assert(m_uuids.count(entry.path) == 0 || m_uuids[entry.path] == uuid);
+      // GPU core dumps can report distinct code-object mappings with the same
+      // device-node path (for example /dev/dri/renderD128), so this path map is
+      // best-effort. Log conflicts rather than aborting core loading.
+      if (m_uuids.count(entry.path) != 0 && m_uuids[entry.path] != uuid &&
+          log)
+        LLDB_LOGF(log,
+                  "%s found conflicting UUID @ %16.16" PRIx64
+                  ": existing %s new %s \"%s\"",
+                  __FUNCTION__, entry.start,
+                  m_uuids[entry.path].GetAsString().c_str(),
+                  uuid.GetAsString().c_str(), entry.path.c_str());
       m_uuids[entry.path] = uuid;
       if (log)
         LLDB_LOGF(log, "%s found UUID @ %16.16" PRIx64 ": %s \"%s\"",

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
@@ -102,6 +102,9 @@ public:
 
   std::vector<lldb_private::CoreNote> GetCoreNotes();
 
+  // Returns the GNU build ID for an ELF image loaded at the given core address.
+  lldb_private::UUID FindBuidIdInCoreMemory(lldb::addr_t address);
+
 protected:
   void Clear();
 
@@ -174,9 +177,6 @@ private:
 
   // Returns the main executable path
   llvm::StringRef GetMainExecutablePath();
-
-  // Returns the value of certain type of note of a given start address
-  lldb_private::UUID FindBuidIdInCoreMemory(lldb::addr_t address);
 
   // Parse a contiguous address range of the process from LOAD segment
   lldb::addr_t


### PR DESCRIPTION
Expose GNU build IDs on AMDGPU code-object modules loaded from merged GPU cores.

  `ProcessAmdGpuCore` now sets the module UUID from the code-object URI when available, or falls back to reading the GNU build ID from the CPU ELF core memory at the code-object load address. This lets LLDB/fblldb resolve AMDGPU sidecar debug files by build ID.

  This also changes `ProcessElfCore::UpdateBuildIdForNTFileEntries()` to log duplicate-path UUID conflicts instead of asserting. Fire merged GPU cores can contain distinct GPU code-object mappings with the same device-node path, for
  example `/dev/dri/renderD128`, but different build IDs.

  Testing

  Built LLDB:

  ```bash
  ninja -C /data/users/chenlii/llvm-project/build/Debug lldb

  Loaded a Fire merged GPU core:

  /data/users/chenlii/llvm-project/build/Debug/bin/lldb -c /tmp/rocgdb_mast_8b2d7g0dptiwu6uv_20260526_165205/mast_coredumps.8b2d7g0dptiwu6uv.merged

  Verified the AMDGPU code-object modules expose build IDs. Example duplicate NT_FILE path evidence from process logging:

  0x00007f4555600000  /dev/dri/renderD128  build_id 9402FEF3...
  0x00007f456ae00000  /dev/dri/renderD128  build_id 1F5E6743...
  0x00007f456b500000  /dev/dri/renderD128  build_id C2863EAB...
  0x00007f456bc00000  /dev/dri/renderD128  build_id F84CE2ED...
  0x00007fbfc9280000  /dev/dri/renderD128  build_id DCAEE886...
  0x00007fbfc98c0000  /dev/dri/renderD128  build_id E9F3C48E...

  With Meta fblldb autoload changes, ran:

  auto-load-debuginfo --force
  target select 1
  bt

  Verified source resolution for the GPU frame:

  * frame #0: 0x00007f4555a67bdc Indexing.hip.pic.o.gfx942.debug`abort at hip_assert.h:30 [inlined]
    frame #1: 0x00007f4555a67bd8 Indexing.hip.pic.o.gfx942.debug`void at::native::(anonymous namespace)::indexSelectSmallIndex<...>(...) at Indexing.hip:1523