### PR TITLE
[lldb][gpu-comparison] Fix compare registers from selected GPU target

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/gpu/gpu_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/gpu/gpu_testcase.py
@@ -2,10 +2,20 @@ from lldbsuite.test.lldbtest import TestBase
 import lldb
 
 # Triple substrings that identify GPU targets.
-_GPU_TRIPLE_PATTERNS = ("amdgcn", "r600", "nvptx", "mockgpu")
+GPU_TRIPLE_PATTERNS = ("amdgcn", "r600", "nvptx", "mockgpu")
 
 # Triple substrings that identify CPU targets.
-_CPU_TRIPLE_PATTERNS = ("x86_64", "aarch64", "arm")
+CPU_TRIPLE_PATTERNS = ("x86_64", "aarch64", "arm")
+
+
+def find_target_by_triple(debugger, patterns):
+    """Find the first target whose triple contains one of the given patterns."""
+    for i in range(debugger.GetNumTargets()):
+        target = debugger.GetTargetAtIndex(i)
+        triple = target.GetTriple()
+        if any(p in triple for p in patterns):
+            return target
+    return None
 
 
 class GpuTestCaseBase(TestBase):
@@ -16,22 +26,17 @@ class GpuTestCaseBase(TestBase):
 
     def _find_target_by_triple(self, patterns):
         """Find the first target whose triple contains one of the given patterns."""
-        for i in range(self.dbg.GetNumTargets()):
-            target = self.dbg.GetTargetAtIndex(i)
-            triple = target.GetTriple()
-            if any(p in triple for p in patterns):
-                return target
-        return None
+        return find_target_by_triple(self.dbg, patterns)
 
     @property
     def cpu_target(self):
         """Return the CPU target by searching for a CPU triple."""
-        return self._find_target_by_triple(_CPU_TRIPLE_PATTERNS)
+        return self._find_target_by_triple(CPU_TRIPLE_PATTERNS)
 
     @property
     def gpu_target(self):
         """Return the GPU target by searching for a GPU triple."""
-        return self._find_target_by_triple(_GPU_TRIPLE_PATTERNS)
+        return self._find_target_by_triple(GPU_TRIPLE_PATTERNS)
 
     @property
     def cpu_process(self):

--- a/lldb/test/API/gpu/comparison/amd/TestAmdGpuCoreFileComparison.py
+++ b/lldb/test/API/gpu/comparison/amd/TestAmdGpuCoreFileComparison.py
@@ -88,6 +88,13 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    def select_gpu(self):
+        """Select the GPU target and keep the LLDB driver state in sync."""
+        lldb_driver = getattr(self, "_active_lldb_driver", None)
+        if lldb_driver:
+            lldb_driver.set_target(self.gpu_target)
+        super().select_gpu()
+
     # ------------------------------------------------------------------
     # Per-core-file setup / teardown helpers
     # ------------------------------------------------------------------
@@ -244,17 +251,62 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
         gdb_driver, lldb_driver, comparator = self._load_core(core_path)
 
         gdb_result = gdb_driver.get_registers()
+
+        gpu_proc = self.gpu_process
+        if not gpu_proc or not gpu_proc.IsValid():
+            self.skipTest("LLDB GPU target not found")
+
+        self.select_gpu()
         lldb_result = lldb_driver.get_registers()
+        self.assertTrue(
+            lldb_result.success,
+            f"Failed to get LLDB GPU registers: {lldb_result.error_message}",
+        )
 
         self.trace(f"\nGDB registers: {len(gdb_result.registers)}")
         self.trace(f"LLDB registers: {len(lldb_result.registers)}")
 
         comparison = comparator.compare_registers(gdb_result, lldb_result)
 
-        if comparison.differences:
-            self.trace(f"\nRegister differences ({len(comparison.differences)}):")
-            for diff in comparison.differences[:10]:
+        value_mismatches = comparison.differences
+        gdb_only_registers = comparison.gdb_only.get("registers", [])
+        lldb_only_registers = comparison.lldb_only.get("registers", [])
+
+        failure_lines = []
+        if value_mismatches:
+            self.trace(f"\nRegister value mismatches ({len(value_mismatches)}):")
+            failure_lines.append(
+                f"Register value mismatches: {len(value_mismatches)}; first 10:"
+            )
+            for diff in value_mismatches[:10]:
                 self.trace(f"  {diff.description}")
+                failure_lines.append(f"  {diff.description}")
+
+        if gdb_only_registers or lldb_only_registers:
+            self.trace(
+                "\nRegister presence mismatches: "
+                f"GDB-only={len(gdb_only_registers)}, "
+                f"LLDB-only={len(lldb_only_registers)}"
+            )
+
+        if gdb_only_registers:
+            preview = ", ".join(gdb_only_registers[:10])
+            self.trace(f"  GDB-only registers: {preview}")
+            failure_lines.append(
+                f"GDB-only registers: {len(gdb_only_registers)}; first 10: "
+                f"{preview}"
+            )
+
+        if lldb_only_registers:
+            preview = ", ".join(lldb_only_registers[:10])
+            self.trace(f"  LLDB-only registers: {preview}")
+            failure_lines.append(
+                f"LLDB-only registers: {len(lldb_only_registers)}; first 10: "
+                f"{preview}"
+            )
+
+        if failure_lines:
+            self.fail("Register comparison failed:\n" + "\n".join(failure_lines))
 
     def _run_local_variables_comparison(self, core_path):
         """Compare GPU local variables between debuggers for a core file.

--- a/lldb/test/API/gpu/comparison/amd/TestAmdGpuCoreFileComparison.py
+++ b/lldb/test/API/gpu/comparison/amd/TestAmdGpuCoreFileComparison.py
@@ -6,7 +6,7 @@ This test verifies that both debuggers produce equivalent results for
 GPU debugging scenarios.
 
 TEST STRUCTURE:
-- TestAmdGpuCoreFileComparison inherits from GpuTestCaseBase and contains
+- TestAmdGpuCoreFileComparison inherits from TestBase and contains
   helper methods for loading core files, comparing variables, etc.
 - For each *.core file in the Inputs/ subdirectory, test methods are
   dynamically generated:
@@ -33,11 +33,8 @@ import glob
 import os
 import shutil
 
-import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test.tools.gpu.gpu_testcase import GpuTestCaseBase
-import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test import configuration
 
 # Add parent directory to path to import the shared comparison framework
@@ -74,7 +71,7 @@ def _get_core_files():
     return sorted(glob.glob(pattern))
 
 
-class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
+class TestAmdGpuCoreFileComparison(TestBase):
     """Compares LLDB and ROCgdb behavior on AMD GPU core files.
 
     For each *.core file in Inputs/, test methods are dynamically added
@@ -82,18 +79,11 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
     test_local_variables__mycore).  Each method loads the core file in both
     debuggers, runs the comparison, and tears down.
 
-    Inherits target selection helpers (cpu_target, gpu_target, select_cpu,
-    select_gpu, cpu_process, gpu_process) from GpuTestCaseBase.
+    LLDB access is routed through LldbDriver only; the test does not use
+    inherited GPU target helpers so debugger state stays in one adapter.
     """
 
     NO_DEBUG_INFO_TESTCASE = True
-
-    def select_gpu(self):
-        """Select the GPU target and keep the LLDB driver state in sync."""
-        lldb_driver = getattr(self, "_active_lldb_driver", None)
-        if lldb_driver:
-            lldb_driver.set_target(self.gpu_target)
-        super().select_gpu()
 
     # ------------------------------------------------------------------
     # Per-core-file setup / teardown helpers
@@ -151,22 +141,6 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
     # Comparison helpers
     # ------------------------------------------------------------------
 
-    def _get_lldb_gpu_local_variables(self, frame):
-        """Get local variables from an LLDB frame as a dict.
-
-        Returns:
-            dict mapping variable name -> {"value": str, "type": str}
-        """
-        lldb_vars = {}
-        vars_list = frame.GetVariables(True, True, False, True)
-        for i in range(vars_list.GetSize()):
-            var = vars_list.GetValueAtIndex(i)
-            lldb_vars[var.GetName()] = {
-                "value": var.GetValue(),
-                "type": var.GetTypeName(),
-            }
-        return lldb_vars
-
     def _compare_variable_sets(self, comparator, gdb_vars, lldb_vars):
         """Compare variable sets between GDB and LLDB.
 
@@ -174,7 +148,8 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
             Tuple of (only_in_gdb, only_in_lldb, read_failures, value_mismatches)
         """
         gdb_var_names = {v.name for v in gdb_vars.variables}
-        lldb_var_names = set(lldb_vars.keys())
+        lldb_var_map = {v.name: v for v in lldb_vars.variables}
+        lldb_var_names = set(lldb_var_map.keys())
 
         only_in_gdb = gdb_var_names - lldb_var_names
         only_in_lldb = lldb_var_names - gdb_var_names
@@ -184,7 +159,7 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
         value_mismatches = []
         for name in common:
             gdb_var = next(v for v in gdb_vars.variables if v.name == name)
-            lldb_value = lldb_vars[name]["value"]
+            lldb_value = lldb_var_map[name].value
             gdb_value = gdb_var.value
 
             if lldb_value is None or lldb_value == "":
@@ -222,29 +197,27 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
         gdb_driver, lldb_driver, comparator = self._load_core(core_path)
 
         gdb_result = gdb_driver.get_all_threads()
+        lldb_cpu = lldb_driver.select_cpu()
+        if not lldb_cpu.success:
+            self.skipTest(lldb_cpu.error_message)
+        cpu_thread_count = lldb_driver.get_thread_count()
 
-        self.select_cpu()
-        cpu_proc = self.cpu_process
-        if not cpu_proc or not cpu_proc.IsValid():
-            self.skipTest("LLDB CPU target not found")
-
-        lldb_cpu_thread_count = cpu_proc.GetNumThreads()
+        lldb_gpu = lldb_driver.select_gpu()
+        if not lldb_gpu.success:
+            self.skipTest(lldb_gpu.error_message)
+        gpu_thread_count = lldb_driver.get_thread_count()
+        lldb_total = cpu_thread_count + gpu_thread_count
 
         self.trace(f"GDB total threads (flat view): {len(gdb_result.threads)}")
-        self.trace(f"LLDB CPU threads: {lldb_cpu_thread_count}")
+        self.trace(f"LLDB CPU threads: {cpu_thread_count}")
+        self.trace(f"LLDB GPU threads: {gpu_thread_count}")
+        self.trace(f"LLDB total (CPU + GPU): {lldb_total}")
 
-        self.select_gpu()
-        gpu_proc = self.gpu_process
-        if gpu_proc and gpu_proc.IsValid():
-            self.trace(f"LLDB GPU threads: {gpu_proc.GetNumThreads()}")
-            lldb_total = lldb_cpu_thread_count + gpu_proc.GetNumThreads()
-            self.trace(f"LLDB total (CPU + GPU): {lldb_total}")
-
-            self.assertEqual(
-                len(gdb_result.threads),
-                lldb_total,
-                f"Total thread count mismatch: GDB={len(gdb_result.threads)}, LLDB={lldb_total}",
-            )
+        self.assertEqual(
+            len(gdb_result.threads),
+            lldb_total,
+            f"Total thread count mismatch: GDB={len(gdb_result.threads)}, LLDB={lldb_total}",
+        )
 
     def _run_register_comparison(self, core_path):
         """Compare register values between debuggers for a core file."""
@@ -252,11 +225,12 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
 
         gdb_result = gdb_driver.get_registers()
 
-        gpu_proc = self.gpu_process
-        if not gpu_proc or not gpu_proc.IsValid():
-            self.skipTest("LLDB GPU target not found")
+        lldb_select_result = lldb_driver.select_gpu()
+        if not lldb_select_result.success:
+            self.skipTest(lldb_select_result.error_message)
+        if lldb_driver.get_thread_count() == 0:
+            self.skipTest("No GPU threads in LLDB")
 
-        self.select_gpu()
         lldb_result = lldb_driver.get_registers()
         self.assertTrue(
             lldb_result.success,
@@ -317,41 +291,30 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
         """
         gdb_driver, lldb_driver, comparator = self._load_core(core_path)
 
-        self.select_gpu()
-        gpu_proc = self.gpu_process
-        if not gpu_proc or not gpu_proc.IsValid():
-            self.skipTest("LLDB GPU target not found")
-
-        if gpu_proc.GetNumThreads() == 0:
+        lldb_select_result = lldb_driver.select_gpu()
+        if not lldb_select_result.success:
+            self.skipTest(lldb_select_result.error_message)
+        if lldb_driver.get_thread_count() == 0:
             self.skipTest("No GPU threads in LLDB")
-
-        lldb_gpu_thread = gpu_proc.GetSelectedThread()
-        if not lldb_gpu_thread.IsValid():
-            lldb_gpu_thread = gpu_proc.GetThreadAtIndex(0)
-
-        lldb_frame = lldb_gpu_thread.GetFrameAtIndex(0)
-        self.trace(
-            f"\nLLDB selected GPU thread: id={lldb_gpu_thread.GetThreadID()}, "
-            f"PC={hex(lldb_frame.GetPC())}, "
-            f"func={lldb_frame.GetFunctionName() or '<unknown>'}"
-        )
 
         # Get local variables from GDB using the default selected thread.
         # IMPORTANT: Do NOT call get_all_threads() here as it changes GDB's
         # selected thread!
         gdb_vars = gdb_driver.get_local_variables()
 
-        # Get local variables from LLDB
-        lldb_vars = self._get_lldb_gpu_local_variables(lldb_frame)
+        # Get local variables from LLDB through the LLDB adapter only.
+        lldb_vars = lldb_driver.get_local_variables()
+        if not lldb_vars.success:
+            self.fail(f"LLDB failed to get local variables: {lldb_vars.error_message}")
 
         self.trace(f"\n=== Local Variables Comparison ===")
         self.trace(f"GDB variables: {len(gdb_vars.variables)}")
-        self.trace(f"LLDB variables: {len(lldb_vars)}")
+        self.trace(f"LLDB variables: {len(lldb_vars.variables)}")
 
         for v in gdb_vars.variables:
             self.trace(f"  GDB: {v.name} ({v.type_name}) = {v.value}")
-        for name, info in lldb_vars.items():
-            self.trace(f"  LLDB: {name} ({info['type']}) = {info['value']}")
+        for v in lldb_vars.variables:
+            self.trace(f"  LLDB: {v.name} ({v.type_name}) = {v.value}")
 
         # Compare
         only_in_gdb, only_in_lldb, read_failures, value_mismatches = (
@@ -377,12 +340,13 @@ class TestAmdGpuCoreFileComparison(GpuTestCaseBase):
 
         # Log per-variable match status
         gdb_var_names = {v.name for v in gdb_vars.variables}
-        common = gdb_var_names & set(lldb_vars.keys())
+        lldb_var_map = {v.name: v for v in lldb_vars.variables}
+        common = gdb_var_names & set(lldb_var_map.keys())
         self.trace(f"\nValue comparison:")
         for name in common:
             gdb_var = next(v for v in gdb_vars.variables if v.name == name)
             gdb_val = gdb_var.value
-            lldb_val = lldb_vars[name]["value"]
+            lldb_val = lldb_var_map[name].value
             normalized_gdb = comparator.normalize_pointer_value(gdb_val)
             normalized_lldb = comparator.normalize_pointer_value(lldb_val)
             match = "MATCH" if normalized_gdb == normalized_lldb else "MISMATCH"

--- a/lldb/test/API/gpu/comparison/framework/comparator.py
+++ b/lldb/test/API/gpu/comparison/framework/comparator.py
@@ -8,7 +8,6 @@ from .debugger_interface import (
     DebuggerResult,
     ThreadInfo,
     FrameInfo,
-    RegisterValue,
     VariableValue,
     ModuleInfo,
 )
@@ -258,7 +257,6 @@ class ResultComparator:
                 result.add_gdb_only("registers", name)
                 continue
 
-            # Compare values
             if gdb_reg.value != lldb_reg.value:
                 result.add_difference(
                     "registers",

--- a/lldb/test/API/gpu/comparison/framework/debugger_interface.py
+++ b/lldb/test/API/gpu/comparison/framework/debugger_interface.py
@@ -28,6 +28,13 @@ class RegisterValue:
     value: int
     size: int = 0
 
+    def __post_init__(self):
+        if self.size > 0:
+            # Compare scalar registers as fixed-width bit patterns so signed
+            # GDB values match LLDB's unsigned representation. For example,
+            # GDB=-1 and LLDB=0xffffffff are the same 32-bit register bits.
+            self.value &= (1 << (self.size * 8)) - 1
+
     def __eq__(self, other):
         if not isinstance(other, RegisterValue):
             return False

--- a/lldb/test/API/gpu/comparison/framework/gdb_driver.py
+++ b/lldb/test/API/gpu/comparison/framework/gdb_driver.py
@@ -494,16 +494,18 @@ try:
         try:
             val = frame.read_register(reg)
             try:
+                size = int(val.type.sizeof)
+            except:
+                size = 0
+            try:
                 int_val = int(val)
                 result["registers"][reg.name] = {{
                     "name": reg.name,
-                    "value": int_val
+                    "value": int_val,
+                    "size": size
                 }}
             except:
-                result["registers"][reg.name] = {{
-                    "name": reg.name,
-                    "value_str": str(val)
-                }}
+                pass
         except:
             pass
 
@@ -518,7 +520,11 @@ print("RESULT_JSON:" + json.dumps(result))
         registers = {}
         for name, reg_data in data.get("registers", {}).items():
             if "value" in reg_data:
-                registers[name] = RegisterValue(name=name, value=reg_data["value"])
+                registers[name] = RegisterValue(
+                    name=name,
+                    value=reg_data["value"],
+                    size=reg_data.get("size", 0),
+                )
 
         return DebuggerResult(
             success=data.get("success", False),

--- a/lldb/test/API/gpu/comparison/framework/lldb_driver.py
+++ b/lldb/test/API/gpu/comparison/framework/lldb_driver.py
@@ -19,6 +19,11 @@ from .debugger_interface import (
     ModuleInfo,
     StopReason,
 )
+from lldbsuite.test.tools.gpu.gpu_testcase import (
+    CPU_TRIPLE_PATTERNS,
+    GPU_TRIPLE_PATTERNS,
+    find_target_by_triple,
+)
 
 
 class LldbDriver(DebuggerInterface):
@@ -70,6 +75,57 @@ class LldbDriver(DebuggerInterface):
         """Update the cached target and process."""
         self._target = target
         self._process = target.GetProcess() if target and target.IsValid() else None
+
+    def _get_selected_frame(self) -> Optional[lldb.SBFrame]:
+        if self._process.GetNumThreads() == 0:
+            return None
+
+        thread = self._process.GetSelectedThread()
+        if not thread.IsValid():
+            thread = self._process.GetThreadAtIndex(0)
+            self._process.SetSelectedThread(thread)
+
+        frame = thread.GetSelectedFrame()
+        if frame.IsValid():
+            return frame
+
+        if thread.GetNumFrames() > 0:
+            thread.SetSelectedFrame(0)
+            return thread.GetFrameAtIndex(0)
+
+        return None
+
+    def _select_target_by_triple(self, patterns, target_name) -> DebuggerResult:
+        target = find_target_by_triple(self._debugger, patterns)
+        if not target or not target.IsValid():
+            return DebuggerResult(
+                success=False, error_message=f"LLDB {target_name} target not found"
+            )
+
+        self._debugger.SetSelectedTarget(target)
+        self.set_target(target)
+        if not self._process or not self._process.IsValid():
+            return DebuggerResult(
+                success=False, error_message=f"LLDB {target_name} process not found"
+            )
+
+        self._get_selected_frame()
+        return DebuggerResult(
+            success=True,
+            extra_data={"target": target},
+        )
+
+    def select_cpu(self) -> DebuggerResult:
+        """Select the CPU target."""
+        return self._select_target_by_triple(CPU_TRIPLE_PATTERNS, "CPU")
+
+    def select_gpu(self) -> DebuggerResult:
+        """Select the GPU target."""
+        return self._select_target_by_triple(GPU_TRIPLE_PATTERNS, "GPU")
+
+    def get_thread_count(self) -> int:
+        """Get the thread count for the selected target/process."""
+        return self._process.GetNumThreads()
 
     def load_core(
         self, core_path: str, executable_path: Optional[str] = None
@@ -319,14 +375,8 @@ class LldbDriver(DebuggerInterface):
             if not self._process or not self._process.IsValid():
                 return DebuggerResult(success=False, error_message="No valid process")
 
-            thread = self._process.GetSelectedThread()
-            if not thread.IsValid():
-                return DebuggerResult(
-                    success=False, error_message="No valid thread selected"
-                )
-
-            frame = thread.GetSelectedFrame()
-            if not frame.IsValid():
+            frame = self._get_selected_frame()
+            if frame is None or not frame.IsValid():
                 return DebuggerResult(
                     success=False, error_message="No valid frame selected"
                 )
@@ -385,10 +435,8 @@ class LldbDriver(DebuggerInterface):
             if not self._process or not self._process.IsValid():
                 return DebuggerResult(success=False, error_message="No valid process")
 
-            thread = self._process.GetSelectedThread()
-            frame = thread.GetSelectedFrame()
-
-            if not frame.IsValid():
+            frame = self._get_selected_frame()
+            if frame is None or not frame.IsValid():
                 return DebuggerResult(
                     success=False, error_message="No valid frame selected"
                 )
@@ -417,10 +465,8 @@ class LldbDriver(DebuggerInterface):
             if not self._process or not self._process.IsValid():
                 return DebuggerResult(success=False, error_message="No valid process")
 
-            thread = self._process.GetSelectedThread()
-            frame = thread.GetSelectedFrame()
-
-            if not frame.IsValid():
+            frame = self._get_selected_frame()
+            if frame is None or not frame.IsValid():
                 return DebuggerResult(
                     success=False, error_message="No valid frame selected"
                 )

--- a/lldb/test/API/gpu/comparison/framework/lldb_driver.py
+++ b/lldb/test/API/gpu/comparison/framework/lldb_driver.py
@@ -66,6 +66,11 @@ class LldbDriver(DebuggerInterface):
         """Get the current process."""
         return self._process
 
+    def set_target(self, target: lldb.SBTarget):
+        """Update the cached target and process."""
+        self._target = target
+        self._process = target.GetProcess() if target and target.IsValid() else None
+
     def load_core(
         self, core_path: str, executable_path: Optional[str] = None
     ) -> DebuggerResult:
@@ -326,6 +331,18 @@ class LldbDriver(DebuggerInterface):
                     success=False, error_message="No valid frame selected"
                 )
 
+            return self.get_registers_from_frame(frame, register_names)
+
+        except Exception as e:
+            return DebuggerResult(success=False, error_message=str(e))
+
+    def get_registers_from_frame(
+        self,
+        frame: lldb.SBFrame,
+        register_names: Optional[List[str]] = None,
+    ) -> DebuggerResult:
+        """Get register values from a specific LLDB frame."""
+        try:
             registers = {}
             reg_sets = frame.GetRegisters()
 
@@ -336,12 +353,26 @@ class LldbDriver(DebuggerInterface):
                     if register_names is not None and name not in register_names:
                         continue
 
+                    error = reg.GetError()
+                    if error.Fail():
+                        continue
+
+                    # Vector registers do not have a scalar value string here;
+                    # GetValueAsUnsigned() can still return a misleading zero.
+                    if reg.GetValue() is None:
+                        continue
+
+                    byte_size = reg.GetByteSize()
                     try:
                         value = reg.GetValueAsUnsigned()
-                        registers[name] = RegisterValue(name=name, value=value)
                     except:
-                        # Some registers may not be convertible to unsigned
-                        pass
+                        continue
+
+                    registers[name] = RegisterValue(
+                        name=name,
+                        value=value,
+                        size=byte_size,
+                    )
 
             return DebuggerResult(success=True, registers=registers)
 


### PR DESCRIPTION
Summary:

Fix a couple issues with the compare registers test:
* test is just doing logging instead of failing if the register mismatch
* gpu process was not selected when fetching lldb registers so we ended up selecting cpu registers
* vector register was not skipped in lldb but skipped in gdb, making lldb only focused on integer register for now
* some register values need to be normalized, e.x., gdb=-1 vs lldb=0xffffffff
* some unavailable registers (LLDB knows this register exists architecturally, but this core does not contain a readable value for it) are returned by lldb api, skipped those

Test Plan:

Run a focus test:
```
  GDB registers: 66
  LLDB registers: 66
  Ran 1 test in 0.695s
  OK
```