### PR TITLE
[LLDB][NVGPU] Enhance NVGPU support with version compatibility checks

### DIFF
--- a/lldb/docs/use/nvgpu-support.rst
+++ b/lldb/docs/use/nvgpu-support.rst
@@ -85,15 +85,29 @@ starting lldb-server.
 Driver compatibility
 ^^^^^^^^^^^^^^^^^^^^
 
-This plugin relies on a header file provided by NVIDIA `cudadebugger.h` that
-contains hardcoded version numbers of the CUDA driver this plugin will interact
-with. This header is provided by the current CUDA Toolkit installation, unless
-specified manually via the `NVGPU_DEBUGGER_INCLUDE_DIR` CMake variable.
-Make sure that this version matches the one of your driver, otherwise this
-plugin won't be able to initialize.
+This plugin is built against a single CUDA debugger-API header
+(`cudadebugger.h`, provided by the CUDA Toolkit installation or the
+`NVGPU_DEBUGGER_INCLUDE_DIR` CMake variable). The header's
+`CUDBG_API_VERSION_MAJOR` identifies the CUDA *major* release the build
+targets.
 
-- The version numbers in this header file are specified by the variables
-  `CUDBG_API_VERSION_MAJOR` and `CUDBG_API_VERSION_MINOR`.
+Support policy: a build works with any CUDA driver -- and reads any GPU
+coredump -- within that same major release. There is no cross-major-release
+compatibility. In other words, an lldb-server (or corefile reader) built
+against, say, CUDA 13.x supports every 13.x driver/coredump, but not 12.x or
+14.x.
+
+- Live debugging: the plugin queries the driver's API version
+  (`cudbgGetAPIVersion`) and negotiates the API revision down to the lesser of
+  the driver's and the compiled header's. An older in-major driver therefore
+  attaches successfully; API features newer than that driver are simply
+  unavailable. A driver from a different major release is rejected with a clear
+  error -- rebuild lldb-server against that major's header.
+- Coredumps: the reader applies the same policy. It reads any in-major
+  coredump and ignores fields the producing driver predates, using the
+  producer version recorded in the coredump's metadata section. A coredump
+  produced by a different major release is loaded best-effort with a warning,
+  since field layouts are not guaranteed across majors.
 - The version of your driver can be obtained via the `DRIVER version` section
   of the `nvidia-smi --version` output.
 

--- a/lldb/include/lldb/Utility/NVGPU/CUDADebuggerVersion.h
+++ b/lldb/include/lldb/Utility/NVGPU/CUDADebuggerVersion.h
@@ -26,6 +26,7 @@
 #include "cudadebugger.h"
 
 #include <cstdint>
+#include <tuple>
 
 /// The CUDA major release this LLDB build targets. Cross-major-release
 /// compatibility is explicitly out of scope: a build works against any
@@ -68,11 +69,8 @@ struct CudbgApiVersion {
   /// Lexicographic comparison over (major, minor, revision), used to pick the
   /// lesser of the compiled and driver versions.
   bool operator<(const CudbgApiVersion &rhs) const {
-    if (major != rhs.major)
-      return major < rhs.major;
-    if (minor != rhs.minor)
-      return minor < rhs.minor;
-    return revision < rhs.revision;
+    return std::tie(major, minor, revision) <
+           std::tie(rhs.major, rhs.minor, rhs.revision);
   }
 
   /// True if this version is at least (maj, min, rev). Use this to gate calls

--- a/lldb/include/lldb/Utility/NVGPU/CUDADebuggerVersion.h
+++ b/lldb/include/lldb/Utility/NVGPU/CUDADebuggerVersion.h
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Version-compatibility helpers for the CUDA debugger API
+/// (`cudadebugger.h`), shared by the live lldb-server NVGPU plugin and the
+/// NVGPU corefile reader.
+///
+/// LLDB's NVGPU plugins are built against a single CUDA debugger-API header
+/// but must work against any CUDA driver -- or read any coredump -- within
+/// that same CUDA *major* release. There is no cross-major-release
+/// compatibility. These macros gate version-specific symbols on the compiled
+/// header's `CUDBG_API_VERSION_*` values; `CUDBG_API_VERSION_REVISION` is a
+/// monotonic build counter and is the reliable in-major discriminator.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_UTILITY_NVGPU_CUDADEBUGGERVERSION_H
+#define LLDB_UTILITY_NVGPU_CUDADEBUGGERVERSION_H
+
+#include "cudadebugger.h"
+
+#include <cstdint>
+
+/// The CUDA major release this LLDB build targets. Cross-major-release
+/// compatibility is explicitly out of scope: a build works against any
+/// driver/coredump within this major only. It is a build constant rather
+/// than something derived from the header so that an accidental cross-major
+/// build is caught by the static_assert below instead of producing cryptic
+/// missing-symbol errors.
+#define LLDB_NVGPU_CUDA_TARGET_MAJOR 13
+
+static_assert(CUDBG_API_VERSION_MAJOR == LLDB_NVGPU_CUDA_TARGET_MAJOR,
+              "LLDB's NVGPU plugins support building against a single CUDA "
+              "debugger-API major release only (see "
+              "LLDB_NVGPU_CUDA_TARGET_MAJOR). The cudadebugger.h on the "
+              "include path is from a different major release.");
+
+/// True if the compiled CUDA debugger API revision is at least `revision`.
+/// Because cross-major builds are rejected above and
+/// `CUDBG_API_VERSION_REVISION` is monotonic within a major, the revision
+/// alone is a sufficient discriminator for version-specific symbols.
+#define LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(revision)                            \
+  (CUDBG_API_VERSION_REVISION >= (revision))
+
+namespace lldb_private::nvgpu {
+
+/// A CUDA debugger API version (major.minor.revision). The live plugin
+/// discovers the driver's version with `cudbgGetAPIVersion` and picks the
+/// revision to use (the lesser of the driver's and the compiled version), so
+/// it needs a value comparable at runtime.
+struct CudbgApiVersion {
+  uint32_t major = 0;
+  uint32_t minor = 0;
+  uint32_t revision = 0;
+
+  /// The version this build was compiled against.
+  static CudbgApiVersion Compiled() {
+    return {CUDBG_API_VERSION_MAJOR, CUDBG_API_VERSION_MINOR,
+            CUDBG_API_VERSION_REVISION};
+  }
+
+  /// Lexicographic comparison over (major, minor, revision), used to pick the
+  /// lesser of the compiled and driver versions.
+  bool operator<(const CudbgApiVersion &rhs) const {
+    if (major != rhs.major)
+      return major < rhs.major;
+    if (minor != rhs.minor)
+      return minor < rhs.minor;
+    return revision < rhs.revision;
+  }
+
+  /// True if this version is at least (maj, min, rev). Use this to gate calls
+  /// to API entry points introduced after the major's baseline: a driver
+  /// older than the compiled header returns an API table that does not
+  /// contain newer (appended) entry points, so calling -- or even reading the
+  /// function pointer of -- such an entry is undefined unless the in-use API
+  /// version guarantees it exists. Gate first, then call.
+  bool AtLeast(uint32_t maj, uint32_t min, uint32_t rev) const {
+    return !(*this < CudbgApiVersion{maj, min, rev});
+  }
+};
+
+} // namespace lldb_private::nvgpu
+
+#endif // LLDB_UTILITY_NVGPU_CUDADEBUGGERVERSION_H

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2162,6 +2162,23 @@ void ObjectFileELF::BuildNVGPUSectionList(SectionList &unified_section_list) {
            dev_seq, sm_seq, cta_seq, warp_seq, lane_seq);
 }
 
+DataExtractor ObjectFileELF::GetNVGPUMetadata() {
+  if (!IsNVGPUCoreFile() || !ParseSectionHeaders())
+    return DataExtractor();
+
+  // The metadata section is file-level data, not part of the synthetic GPU
+  // hierarchy built above, so it is not surfaced as a Section. Find its ELF
+  // header and return a view over its file window.
+  for (const ELFSectionHeaderInfo &H : m_section_headers) {
+    if (H.GetNVGPUSectionType() != eSectionTypeNVGPUMetadata)
+      continue;
+    DataExtractor data;
+    GetData(H.sh_offset, H.sh_size, data);
+    return data;
+  }
+  return DataExtractor();
+}
+
 static SectionType GetSectionTypeFromName(llvm::StringRef Name) {
   if (Name.consume_front(".debug_"))
     return ObjectFile::GetDWARFSectionTypeFromName(Name);

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -1801,6 +1801,9 @@ void ObjectFileELF::BuildNVGPUSectionList(SectionList &unified_section_list) {
   uint32_t warp_seq = 0;
   uint32_t lane_seq = 0;
 
+  // Section index of the coredump metadata table, if present.
+  std::optional<size_t> metadata_section_idx;
+
   SectionSP root_sp = std::make_shared<Section>(
       module_sp, this, nvgpu::MakeID(nvgpu::SectionKind::Root, 0),
       ConstString("nvgpucore"), eSectionTypeNVGPURoot,
@@ -2109,12 +2112,16 @@ void ObjectFileELF::BuildNVGPUSectionList(SectionList &unified_section_list) {
       root_sp->GetChildren().AddSection(leaf);
       break;
     }
+    case eSectionTypeNVGPUMetadata:
+      // Record now; surfaced under root after the device-hierarchy check so a
+      // metadata-only (deviceless) file is still rejected below.
+      metadata_section_idx = i;
+      break;
     default:
-      // Device table, lane table, and unrelated metadata / context /
-      // grid / module / param-memory sections fall through. The device
-      // and lane tables are consulted lazily via `GetOrCreateAncestor`
-      // for row data windows; everything else is intentionally not
-      // surfaced in the synthetic tree.
+      // Device table, lane table, and unrelated context / grid / module /
+      // param-memory sections fall through. The device and lane tables are
+      // consulted lazily via `GetOrCreateAncestor` for row data windows;
+      // everything else is intentionally not surfaced in the synthetic tree.
       break;
     }
   }
@@ -2136,6 +2143,26 @@ void ObjectFileELF::BuildNVGPUSectionList(SectionList &unified_section_list) {
     Debugger::ReportWarning(
         "GPU corefile contains no device hierarchy and cannot be loaded.");
     return;
+  }
+
+  // Surface the coredump metadata section as a leaf under nvgpu-root so
+  // consumers (ProcessNVGPUCore) can read its producer driver/CUDA version via
+  // the normal section APIs. It is not part of the device hierarchy and
+  // carries no VM range. Added after the device-hierarchy check above so it
+  // never resurrects an otherwise-empty (deviceless) corefile.
+  if (metadata_section_idx) {
+    const ELFSectionHeaderInfo &h = m_section_headers[*metadata_section_idx];
+    if (h.IsTruncated(file_size)) {
+      truncated_sections.push_back(h.section_name.GetStringRef().str());
+    } else {
+      SectionSP meta_leaf = std::make_shared<Section>(
+          root_sp, module_sp, this,
+          nvgpu::MakeID(nvgpu::SectionKind::Leaf, leaf_seq++),
+          ConstString("metadata"), eSectionTypeNVGPUMetadata,
+          /*file_addr=*/0, /*byte_size=*/0, h.sh_offset, h.sh_size,
+          /*log2align=*/0, /*flags=*/0);
+      root_sp->GetChildren().AddSection(meta_leaf);
+    }
   }
 
   // Install the new hierarchy into both the ObjectFile's section list
@@ -2160,23 +2187,6 @@ void ObjectFileELF::BuildNVGPUSectionList(SectionList &unified_section_list) {
            "BuildNVGPUSectionList: built tree with {0} devices, {1} SMs, "
            "{2} CTAs, {3} warps, {4} lanes",
            dev_seq, sm_seq, cta_seq, warp_seq, lane_seq);
-}
-
-DataExtractor ObjectFileELF::GetNVGPUMetadata() {
-  if (!IsNVGPUCoreFile() || !ParseSectionHeaders())
-    return DataExtractor();
-
-  // The metadata section is file-level data, not part of the synthetic GPU
-  // hierarchy built above, so it is not surfaced as a Section. Find its ELF
-  // header and return a view over its file window.
-  for (const ELFSectionHeaderInfo &H : m_section_headers) {
-    if (H.GetNVGPUSectionType() != eSectionTypeNVGPUMetadata)
-      continue;
-    DataExtractor data;
-    GetData(H.sh_offset, H.sh_size, data);
-    return data;
-  }
-  return DataExtractor();
 }
 
 static SectionType GetSectionTypeFromName(llvm::StringRef Name) {

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -147,6 +147,13 @@ public:
   size_t ReadSectionData(lldb_private::Section *section,
                          lldb_private::DataExtractor &section_data) override;
 
+  /// For NVGPU corefiles, return a DataExtractor over the raw bytes of the
+  /// `.cudbg.meta` metadata section (producer driver / CUDA version), or an
+  /// empty extractor if there is none. This is file-level metadata rather
+  /// than part of the synthetic GPU section hierarchy, so it is read straight
+  /// from the ELF section headers instead of being surfaced as a Section.
+  lldb_private::DataExtractor GetNVGPUMetadata();
+
   llvm::ArrayRef<elf::ELFProgramHeader> ProgramHeaders();
   lldb_private::DataExtractor GetSegmentData(const elf::ELFProgramHeader &H);
 

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -147,13 +147,6 @@ public:
   size_t ReadSectionData(lldb_private::Section *section,
                          lldb_private::DataExtractor &section_data) override;
 
-  /// For NVGPU corefiles, return a DataExtractor over the raw bytes of the
-  /// `.cudbg.meta` metadata section (producer driver / CUDA version), or an
-  /// empty extractor if there is none. This is file-level metadata rather
-  /// than part of the synthetic GPU section hierarchy, so it is read straight
-  /// from the ELF section headers instead of being surfaced as a Section.
-  lldb_private::DataExtractor GetNVGPUMetadata();
-
   llvm::ArrayRef<elf::ELFProgramHeader> ProgramHeaders();
   lldb_private::DataExtractor GetSegmentData(const elf::ELFProgramHeader &H);
 

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
@@ -37,8 +37,10 @@ llvm::Expected<DeviceEntry> DeviceEntry::Decode(const DataExtractor &data,
   // Since CUDA driver r400.
   out.numUniformRegsPrWarp = data.GetU32(offset_ptr);
   out.numUniformPredicatesPrWarp = data.GetU32(offset_ptr);
-  // Since CUDA driver r575.
+  // Since CUDA driver r575 (CUDBG API revision 156).
+#if LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(156)
   out.numConvergenceBarriersPrWarp = data.GetU32(offset_ptr);
+#endif
   return out;
 }
 
@@ -58,8 +60,10 @@ llvm::Expected<SMEntry> SMEntry::Decode(const DataExtractor &data,
   out.clusterExceptionTargetBlockIdxX = data.GetU32(offset_ptr);
   out.clusterExceptionTargetBlockIdxY = data.GetU32(offset_ptr);
   out.clusterExceptionTargetBlockIdxZ = data.GetU32(offset_ptr);
-  // Since CUDA driver r580.
+  // Since CUDA driver r580 (CUDBG API revision 163).
+#if LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(163)
   out.exceptionString = data.GetAddress(offset_ptr);
+#endif
   return out;
 }
 
@@ -110,10 +114,12 @@ llvm::Expected<WarpEntry> WarpEntry::Decode(const DataExtractor &data,
   out.cbuActiveLanesMask = data.GetU32(offset_ptr);
   out.cbuExitedLanesMask = data.GetU32(offset_ptr);
   out.cbuCollectiveLanesMask = data.GetU32(offset_ptr);
-  // Since CUDA driver r590.
+  // Since CUDA driver r590 (CUDBG API revision 167).
+#if LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(167)
   out.barrierScope = data.GetU32(offset_ptr);
   out.padding3 = data.GetU32(offset_ptr);
   out.additionalBarrierInfo = data.GetAddress(offset_ptr);
+#endif
   return out;
 }
 
@@ -133,13 +139,36 @@ llvm::Expected<LaneEntry> LaneEntry::Decode(const DataExtractor &data,
   out.callDepth = data.GetU32(offset_ptr);
   out.syscallCallDepth = data.GetU32(offset_ptr);
   out.ccRegister = data.GetU32(offset_ptr);
-  // Since CUDA driver r575.
+  // Since CUDA driver r575 (CUDBG API revision 156).
+#if LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(156)
   out.cbuThreadState = data.GetU32(offset_ptr);
   out.padding0 = data.GetU32(offset_ptr);
-  // Since CUDA driver r615.
+#endif
+  // Since CUDA driver r615 (CUDBG API revision 192).
+#if LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(192)
   out.rpcLo = data.GetU32(offset_ptr);
   out.rpcHi = data.GetU32(offset_ptr);
+#endif
   return out;
+}
+
+ProducerInfo DecodeProducerInfo(const DataExtractor &data) {
+  ProducerInfo info;
+  if (data.GetByteSize() == 0)
+    return info; // No metadata section; has_metadata stays false.
+
+  // CudbgMetaDataEntry layout (since CUDA driver r565): uint64 generatorName,
+  // uint32 driverVersion{Major,Minor}, uint32 cudaDriverVersion{Major,Minor},
+  // then flags/timestamp we don't need. driverVersionMajor is the NVML driver
+  // branch (e.g. 575/580/615); it is not set on Tegra (stays 0 = "unknown").
+  offset_t offset = 0;
+  data.GetU64(&offset); // generatorName (string-table index; unused)
+  info.driver_branch = data.GetU32(&offset);
+  data.GetU32(&offset); // driverVersionMinor (unused)
+  info.cuda_major = data.GetU32(&offset);
+  info.cuda_minor = data.GetU32(&offset);
+  info.has_metadata = true;
+  return info;
 }
 
 std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane) {

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.cpp
@@ -152,22 +152,21 @@ llvm::Expected<LaneEntry> LaneEntry::Decode(const DataExtractor &data,
   return out;
 }
 
-ProducerInfo DecodeProducerInfo(const DataExtractor &data) {
-  ProducerInfo info;
+std::optional<ProducerInfo> DecodeProducerInfo(const DataExtractor &data) {
   if (data.GetByteSize() == 0)
-    return info; // No metadata section; has_metadata stays false.
+    return std::nullopt; // No metadata section.
 
   // CudbgMetaDataEntry layout (since CUDA driver r565): uint64 generatorName,
   // uint32 driverVersion{Major,Minor}, uint32 cudaDriverVersion{Major,Minor},
-  // then flags/timestamp we don't need. driverVersionMajor is the NVML driver
+  // then flags/timestamp we don't need. driverVersionMajor is the GPU driver
   // branch (e.g. 575/580/615); it is not set on Tegra (stays 0 = "unknown").
+  ProducerInfo info;
   offset_t offset = 0;
   data.GetU64(&offset); // generatorName (string-table index; unused)
   info.driver_branch = data.GetU32(&offset);
   data.GetU32(&offset); // driverVersionMinor (unused)
   info.cuda_major = data.GetU32(&offset);
   info.cuda_minor = data.GetU32(&offset);
-  info.has_metadata = true;
   return info;
 }
 
@@ -180,7 +179,7 @@ std::string FormatThreadName(const CTAEntry &cta, const LaneEntry &lane) {
 std::optional<StopAttribution>
 ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
                        lldb::SectionSP warp_section_sp,
-                       lldb::SectionSP sm_section_sp, ObjectFileELF *core) {
+                       lldb::SectionSP sm_section_sp, ObjectFile *core) {
   if (lane.exception != 0)
     return StopAttribution{lane.exception, false, ""};
 

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
@@ -37,8 +37,8 @@
 // version-specific field reads below) and the single-major static_assert.
 #include "lldb/Utility/NVGPU/CUDADebuggerVersion.h"
 
-#include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
 #include "lldb/Core/Section.h"
+#include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
@@ -61,8 +61,6 @@ struct ProducerInfo {
   /// CUDA driver version (e.g. 13/0) reported by the producer.
   uint32_t cuda_major = 0;
   uint32_t cuda_minor = 0;
-  /// Whether a metadata section was found and decoded for this coredump.
-  bool has_metadata = false;
 };
 
 /// One row of a nvgpu-device-table.
@@ -116,16 +114,15 @@ struct LaneEntry : CudbgThreadTableEntry {
 };
 
 /// Decode the producer version from the raw bytes of the coredump metadata
-/// section. Returns a default-constructed
-/// `ProducerInfo` (`has_metadata == false`) if `data` is empty.
-ProducerInfo DecodeProducerInfo(const DataExtractor &data);
+/// section. Returns std::nullopt if `data` is empty (no metadata section).
+std::optional<ProducerInfo> DecodeProducerInfo(const DataExtractor &data);
 
 /// Read `section_sp`'s data window from `core` and decode it into an
 /// `EntryT` (one of the wrapper structs above). Returns the parse error if
 /// either input is missing or `EntryT::Decode` fails.
 template <typename EntryT>
 llvm::Expected<EntryT> ReadAndDecode(lldb::SectionSP section_sp,
-                                     ObjectFileELF *core) {
+                                     ObjectFile *core) {
   if (!section_sp || !core)
     return llvm::createStringError("missing section or core object file");
   DataExtractor data;
@@ -173,7 +170,7 @@ struct StopAttribution {
 std::optional<StopAttribution>
 ComputeStopAttribution(const LaneEntry &lane, uint32_t lane_idx,
                        lldb::SectionSP warp_section_sp,
-                       lldb::SectionSP sm_section_sp, ObjectFileELF *core);
+                       lldb::SectionSP sm_section_sp, ObjectFile *core);
 
 } // namespace lldb_private::nvgpu_core
 

--- a/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/CudbgEntryParser.h
@@ -33,6 +33,10 @@
 // since the CudbgXxxTableEntry types are already declared.
 #undef SHT_LOUSER
 
+// Brings in cudadebugger.h (for the CUDBG_API_VERSION_* macros that gate the
+// version-specific field reads below) and the single-major static_assert.
+#include "lldb/Utility/NVGPU/CUDADebuggerVersion.h"
+
 #include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Utility/DataExtractor.h"
@@ -46,6 +50,20 @@
 #include <string>
 
 namespace lldb_private::nvgpu_core {
+
+/// Version of the driver/toolkit that produced a coredump, decoded from the
+/// `CudbgMetaDataEntry` metadata section. Used for diagnostics (logging the
+/// producer version and warning on a cross-major coredump).
+struct ProducerInfo {
+  /// Driver branch major (e.g. 575/580/615), matching the "Since CUDA
+  /// driver rXXX" annotations in cudacoredump.h.
+  uint32_t driver_branch = 0;
+  /// CUDA driver version (e.g. 13/0) reported by the producer.
+  uint32_t cuda_major = 0;
+  uint32_t cuda_minor = 0;
+  /// Whether a metadata section was found and decoded for this coredump.
+  bool has_metadata = false;
+};
 
 /// One row of a nvgpu-device-table.
 struct DeviceEntry : CudbgDeviceTableEntry {
@@ -96,6 +114,11 @@ struct LaneEntry : CudbgThreadTableEntry {
                                           lldb::offset_t *offset_ptr,
                                           uint64_t entry_size);
 };
+
+/// Decode the producer version from the raw bytes of the coredump metadata
+/// section. Returns a default-constructed
+/// `ProducerInfo` (`has_metadata == false`) if `data` is empty.
+ProducerInfo DecodeProducerInfo(const DataExtractor &data);
 
 /// Read `section_sp`'s data window from `core` and decode it into an
 /// `EntryT` (one of the wrapper structs above). Returns the parse error if

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
@@ -18,6 +18,7 @@
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Host/FileSystem.h"
+#include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/MemoryRegionInfo.h"
 #include "lldb/Target/Platform.h"
@@ -104,10 +105,10 @@ bool ProcessNVGPUCore::CanDebug(TargetSP target_sp,
   return false;
 }
 
-ObjectFileELF *ProcessNVGPUCore::GetCoreObjectFile() const {
+ObjectFile *ProcessNVGPUCore::GetCoreObjectFile() const {
   if (!m_core_module_sp)
     return nullptr;
-  return llvm::dyn_cast<ObjectFileELF>(m_core_module_sp->GetObjectFile());
+  return m_core_module_sp->GetObjectFile();
 }
 
 Status ProcessNVGPUCore::DoLoadCore() {
@@ -126,7 +127,7 @@ Status ProcessNVGPUCore::DoLoadCore() {
           target.GetDebugger().GetPlatformList().GetOrCreate("nvgpu"))
     target.SetPlatform(nvgpu_platform);
 
-  ObjectFileELF *core = GetCoreObjectFile();
+  ObjectFile *core = GetCoreObjectFile();
   if (!core)
     return Status::FromErrorString("core module is not an ELF object file");
 
@@ -141,7 +142,7 @@ Status ProcessNVGPUCore::DoLoadCore() {
         "NVGPU corefile did not produce a nvgpucore root section "
         "(likely missing or malformed nvgpu-device-table)");
 
-  LoadProducerInfo(core);
+  LoadProducerInfo(*section_list);
 
   // Register the corefile module itself in the target's module list so it
   // shows up in `image list` and is reachable from the SBModule API. Without
@@ -167,7 +168,7 @@ llvm::Error ProcessNVGPUCore::LoadCubinModules() {
   Log *log = GetLog(LLDBLog::Process);
   LLDB_LOG(log, "ProcessNVGPUCore::LoadCubinModules()");
 
-  ObjectFileELF *core = GetCoreObjectFile();
+  ObjectFile *core = GetCoreObjectFile();
   Target &target = GetTarget();
   ModuleList loaded_modules;
   const FileSpec &core_file = core->GetFileSpec();
@@ -219,12 +220,26 @@ llvm::Error ProcessNVGPUCore::LoadCubinModules() {
   return llvm::Error::success();
 }
 
-void ProcessNVGPUCore::LoadProducerInfo(ObjectFileELF *core) {
+std::optional<DataExtractor>
+ProcessNVGPUCore::GetNVGPUMetadata(const SectionList &sections) {
+  // The metadata leaf hangs under the nvgpucore root, so search recursively.
+  SectionSP sect_sp = sections.FindSectionByType(eSectionTypeNVGPUMetadata,
+                                                 /*check_children=*/true);
+  if (!sect_sp)
+    return std::nullopt;
+  DataExtractor data;
+  if (sect_sp->GetSectionData(data))
+    return data;
+  return std::nullopt;
+}
+
+void ProcessNVGPUCore::LoadProducerInfo(const SectionList &sections) {
   Log *log = GetLog(LLDBLog::Process);
 
-  m_producer = nvgpu_core::DecodeProducerInfo(core->GetNVGPUMetadata());
+  if (std::optional<DataExtractor> metadata = GetNVGPUMetadata(sections))
+    m_producer = nvgpu_core::DecodeProducerInfo(*metadata);
 
-  if (!m_producer.has_metadata) {
+  if (!m_producer) {
     // The metadata section was added in driver r565, so every supported
     // in-major coredump has it. A missing section means we can't confirm the
     // producing driver matches this build; reads stay in-bounds (absent
@@ -238,22 +253,22 @@ void ProcessNVGPUCore::LoadProducerInfo(ObjectFileELF *core) {
     return;
   }
 
-  LLDB_LOG(log, "NVGPU corefile producer: NVML driver branch r{0}, CUDA {1}.{2}",
-           m_producer.driver_branch, m_producer.cuda_major,
-           m_producer.cuda_minor);
+  LLDB_LOG(log, "NVGPU corefile producer: GPU driver branch r{0}, CUDA {1}.{2}",
+           m_producer->driver_branch, m_producer->cuda_major,
+           m_producer->cuda_minor);
 
   // Single-major policy: a coredump from a different CUDA major release may
   // use an incompatible field layout. Don't fail the load (the per-entry-size
   // zero-fill still keeps reads in-bounds), but surface a warning to the user
   // -- not just the log channel -- since GPU state may be decoded incorrectly.
-  if (m_producer.cuda_major != 0 &&
-      m_producer.cuda_major != CUDBG_API_VERSION_MAJOR)
+  if (m_producer->cuda_major != 0 &&
+      m_producer->cuda_major != CUDBG_API_VERSION_MAJOR)
     Debugger::ReportWarning(
         llvm::formatv(
             "NVGPU corefile was produced by CUDA {0}.{1}, but this debugger "
             "was built for CUDA {2}.x. Cross-major-release coredumps are not "
             "supported; some GPU state may be missing or decoded incorrectly.",
-            m_producer.cuda_major, m_producer.cuda_minor,
+            m_producer->cuda_major, m_producer->cuda_minor,
             CUDBG_API_VERSION_MAJOR)
             .str(),
         GetTarget().GetDebugger().GetID());
@@ -263,7 +278,7 @@ bool ProcessNVGPUCore::DoUpdateThreadList(ThreadList &old_thread_list,
                                           ThreadList &new_thread_list) {
   Log *log = GetLog(LLDBLog::Process);
 
-  ObjectFileELF *core = GetCoreObjectFile();
+  ObjectFile *core = GetCoreObjectFile();
 
   uint32_t tid = 0;
 
@@ -344,7 +359,7 @@ size_t ProcessNVGPUCore::DoReadMemory(addr_t addr, void *buf, size_t size,
 /// range.
 static size_t ReadFromMemorySection(SectionSP mem_section, addr_t addr,
                                     void *buf, size_t size,
-                                    ObjectFileELF *core) {
+                                    ObjectFile *core) {
   if (!mem_section || !mem_section->ContainsFileAddress(addr))
     return 0;
   DataExtractor data;
@@ -368,7 +383,7 @@ size_t ProcessNVGPUCore::DoReadMemory(const AddressSpec &addr_spec,
            "size={2}",
            addr, info.name, size);
 
-  ObjectFileELF *core = GetCoreObjectFile();
+  ObjectFile *core = GetCoreObjectFile();
 
   // Get the thread from the AddressSpec. An absent thread is the API's
   // expected signal (not all callers attach one), so we don't surface it

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.cpp
@@ -27,6 +27,7 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/NVGPU/CUDAAddressSpaces.h"
 #include "lldb/Utility/NVGPU/NVGPUSectionID.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Threading.h"
 
 using namespace lldb;
@@ -140,6 +141,8 @@ Status ProcessNVGPUCore::DoLoadCore() {
         "NVGPU corefile did not produce a nvgpucore root section "
         "(likely missing or malformed nvgpu-device-table)");
 
+  LoadProducerInfo(core);
+
   // Register the corefile module itself in the target's module list so it
   // shows up in `image list` and is reachable from the SBModule API. Without
   // this, target.modules only contains the cubin sub-modules added by
@@ -214,6 +217,46 @@ llvm::Error ProcessNVGPUCore::LoadCubinModules() {
 
   target.ModulesDidLoad(loaded_modules);
   return llvm::Error::success();
+}
+
+void ProcessNVGPUCore::LoadProducerInfo(ObjectFileELF *core) {
+  Log *log = GetLog(LLDBLog::Process);
+
+  m_producer = nvgpu_core::DecodeProducerInfo(core->GetNVGPUMetadata());
+
+  if (!m_producer.has_metadata) {
+    // The metadata section was added in driver r565, so every supported
+    // in-major coredump has it. A missing section means we can't confirm the
+    // producing driver matches this build; reads stay in-bounds (absent
+    // fields read back as zero via the per-entry-size zero-fill in Decode),
+    // but surface a warning since GPU state may be missing or misdecoded.
+    Debugger::ReportWarning(
+        "NVGPU corefile has no metadata section; the producing driver version "
+        "could not be determined and some GPU state may be missing or decoded "
+        "incorrectly.",
+        GetTarget().GetDebugger().GetID());
+    return;
+  }
+
+  LLDB_LOG(log, "NVGPU corefile producer: NVML driver branch r{0}, CUDA {1}.{2}",
+           m_producer.driver_branch, m_producer.cuda_major,
+           m_producer.cuda_minor);
+
+  // Single-major policy: a coredump from a different CUDA major release may
+  // use an incompatible field layout. Don't fail the load (the per-entry-size
+  // zero-fill still keeps reads in-bounds), but surface a warning to the user
+  // -- not just the log channel -- since GPU state may be decoded incorrectly.
+  if (m_producer.cuda_major != 0 &&
+      m_producer.cuda_major != CUDBG_API_VERSION_MAJOR)
+    Debugger::ReportWarning(
+        llvm::formatv(
+            "NVGPU corefile was produced by CUDA {0}.{1}, but this debugger "
+            "was built for CUDA {2}.x. Cross-major-release coredumps are not "
+            "supported; some GPU state may be missing or decoded incorrectly.",
+            m_producer.cuda_major, m_producer.cuda_minor,
+            CUDBG_API_VERSION_MAJOR)
+            .str(),
+        GetTarget().GetDebugger().GetID());
 }
 
 bool ProcessNVGPUCore::DoUpdateThreadList(ThreadList &old_thread_list,

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
@@ -25,7 +25,7 @@
 #include "lldb/Target/PostMortemProcess.h"
 #include "lldb/lldb-forward.h"
 
-class ObjectFileELF;
+#include <optional>
 
 class ProcessNVGPUCore : public lldb_private::PostMortemProcess {
 public:
@@ -88,7 +88,7 @@ public:
                       const lldb_private::AddressSpaceInfo &info, void *buf,
                       size_t size, lldb_private::Status &error) override;
 
-  ObjectFileELF *GetCoreObjectFile() const;
+  lldb_private::ObjectFile *GetCoreObjectFile() const;
 
 protected:
   lldb_private::Status
@@ -98,11 +98,15 @@ protected:
 private:
   llvm::Error LoadCubinModules();
 
-  /// Decode the coredump metadata section (if present) into `m_producer` and
-  /// log the producer driver/CUDA version. Never fails: a missing or
-  /// undecodable metadata section is treated as the oldest supported
-  /// in-major driver (log-and-degrade).
-  void LoadProducerInfo(ObjectFileELF *core);
+  /// Decode the coredump metadata section (if present) into `m_producer`, log
+  /// the producer driver/CUDA version, and warn the user if it is missing or
+  /// from a different CUDA major release.
+  void LoadProducerInfo(const lldb_private::SectionList &sections);
+
+  /// Raw bytes of the `.cudbg.meta` metadata section (producer driver / CUDA
+  /// version), or std::nullopt if the coredump has no such section.
+  std::optional<lldb_private::DataExtractor>
+  GetNVGPUMetadata(const lldb_private::SectionList &sections);
 
   /// Find the nvgpu-global-memory or nvgpu-managed-memory leaf section
   /// under the nvgpucore root that contains the given GPU virtual address.
@@ -118,8 +122,8 @@ private:
   lldb::ModuleSP m_core_module_sp;
   lldb::SectionSP m_root_sp;
   /// Driver/toolkit version that produced this coredump (from the metadata
-  /// section). Defaults to "unknown / no metadata" until `DoLoadCore` runs.
-  lldb_private::nvgpu_core::ProducerInfo m_producer;
+  /// section), or std::nullopt if the coredump has no decodable metadata.
+  std::optional<lldb_private::nvgpu_core::ProducerInfo> m_producer;
   /// First thread with an attributed CUDA exception.
   lldb::tid_t m_exception_tid = LLDB_INVALID_THREAD_ID;
   /// First thread stopped on an inline `trap;` / `__trap()`.

--- a/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/ProcessNVGPUCore.h
@@ -20,6 +20,8 @@
 #ifndef LLDB_SOURCE_PLUGINS_PROCESS_NVGPU_CORE_PROCESSNVGPUCORE_H
 #define LLDB_SOURCE_PLUGINS_PROCESS_NVGPU_CORE_PROCESSNVGPUCORE_H
 
+#include "CudbgEntryParser.h"
+
 #include "lldb/Target/PostMortemProcess.h"
 #include "lldb/lldb-forward.h"
 
@@ -96,6 +98,12 @@ protected:
 private:
   llvm::Error LoadCubinModules();
 
+  /// Decode the coredump metadata section (if present) into `m_producer` and
+  /// log the producer driver/CUDA version. Never fails: a missing or
+  /// undecodable metadata section is treated as the oldest supported
+  /// in-major driver (log-and-degrade).
+  void LoadProducerInfo(ObjectFileELF *core);
+
   /// Find the nvgpu-global-memory or nvgpu-managed-memory leaf section
   /// under the nvgpucore root that contains the given GPU virtual address.
   ///
@@ -109,6 +117,9 @@ private:
 
   lldb::ModuleSP m_core_module_sp;
   lldb::SectionSP m_root_sp;
+  /// Driver/toolkit version that produced this coredump (from the metadata
+  /// section). Defaults to "unknown / no metadata" until `DoLoadCore` runs.
+  lldb_private::nvgpu_core::ProducerInfo m_producer;
   /// First thread with an attributed CUDA exception.
   lldb::tid_t m_exception_tid = LLDB_INVALID_THREAD_ID;
   /// First thread stopped on an inline `trap;` / `__trap()`.

--- a/lldb/source/Plugins/Process/nvgpu-core/RegisterContextNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/RegisterContextNVGPUCore.cpp
@@ -11,8 +11,8 @@
 #include "SectionUtils.h"
 #include "ThreadNVGPUCore.h"
 
-#include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
 #include "lldb/Core/Section.h"
+#include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/LLDBLog.h"
@@ -27,7 +27,7 @@ using namespace lldb;
 using namespace lldb_private;
 
 RegisterContextNVGPUCore::RegisterContextNVGPUCore(Thread &thread,
-                                                   ObjectFileELF *core)
+                                                   ObjectFile *core)
     : RegisterContext(thread, 0) {
   if (!core)
     return;

--- a/lldb/source/Plugins/Process/nvgpu-core/RegisterContextNVGPUCore.h
+++ b/lldb/source/Plugins/Process/nvgpu-core/RegisterContextNVGPUCore.h
@@ -13,8 +13,6 @@
 #include "lldb/Utility/NVGPU/SASSRegisterInfo.h"
 #include "lldb/lldb-forward.h"
 
-class ObjectFileELF;
-
 namespace lldb_private {
 
 class RegisterContextNVGPUCore : public RegisterContext {
@@ -34,7 +32,7 @@ public:
   ///     ObjectFile for the corefile, used to read the lane / warp / device
   ///     section data. May be null, in which case the register buffer is
   ///     left zero-initialized.
-  RegisterContextNVGPUCore(Thread &thread, ObjectFileELF *core);
+  RegisterContextNVGPUCore(Thread &thread, ObjectFile *core);
 
   ~RegisterContextNVGPUCore() override;
 

--- a/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
+++ b/lldb/source/Plugins/Process/nvgpu-core/ThreadNVGPUCore.cpp
@@ -11,8 +11,8 @@
 #include "ProcessNVGPUCore.h"
 #include "RegisterContextNVGPUCore.h"
 
-#include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
 #include "lldb/Core/Section.h"
+#include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Target/StopInfo.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
@@ -31,7 +31,7 @@ ThreadNVGPUCore::ThreadNVGPUCore(Process &process, tid_t tid,
   // Decode the CTA and lane rows once so the thread name and stop
   // attribution are cached, instead of re-decoding on every query.
   auto &nvgpu_process = static_cast<ProcessNVGPUCore &>(process);
-  ObjectFileELF *core = nvgpu_process.GetCoreObjectFile();
+  ObjectFile *core = nvgpu_process.GetCoreObjectFile();
   auto cta_or =
       nvgpu_core::ReadAndDecode<nvgpu_core::CTAEntry>(GetCTASection(), core);
   auto lane_or =

--- a/lldb/source/Utility/NVGPU/CUDAException.cpp
+++ b/lldb/source/Utility/NVGPU/CUDAException.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Utility/NVGPU/CUDAException.h"
+#include "lldb/Utility/NVGPU/CUDADebuggerVersion.h"
 #include "llvm/Support/FormatVariadic.h"
 
 #include <cassert>
@@ -41,12 +42,21 @@ llvm::StringRef lldb_private::CUDAExceptionToString(CUDBGException_t exception) 
     return "Cluster Out-of-range Address";
   case CUDBG_EXCEPTION_WARP_STACK_CANARY:
     return "Warp Stack Canary";
+  // Exception codes 20-22 first appear in CUDBG API revision 163 (CUDA 13.0
+  // / driver r580). Guard so the plugin still builds against older in-major
+  // headers that lack these enumerators; unknown codes fall through to the
+  // default below.
+#if LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(163)
   case CUDBG_EXCEPTION_WARP_TMEM_ACCESS_CHECK:
     return "Warp Tensor Memory Access Check";
   case CUDBG_EXCEPTION_WARP_TMEM_LEAK:
     return "Warp Tensor Memory Leak";
   case CUDBG_EXCEPTION_WARP_CALL_REQUIRES_NEWER_DRIVER:
     return "Warp Call Requires Newer Driver";
+#endif
+  // Exception codes 23-35 first appear in CUDBG API revision 167 (CUDA 13.1
+  // / driver r590).
+#if LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(167)
   case CUDBG_EXCEPTION_WARP_MISALIGNED_PC:
     return "Warp Misaligned PC";
   case CUDBG_EXCEPTION_WARP_PC_OVERFLOW:
@@ -73,6 +83,7 @@ llvm::StringRef lldb_private::CUDAExceptionToString(CUDBGException_t exception) 
     return "Warp Block Not Present";
   case CUDBG_EXCEPTION_WARP_USER_STACK_OVERFLOW:
     return "Warp User Stack Overflow";
+#endif
   default:
     return "Device Unknown Exception";
   }

--- a/lldb/tools/lldb-server/Plugins/NVGPU/CUDADebuggerAPI.cpp
+++ b/lldb/tools/lldb-server/Plugins/NVGPU/CUDADebuggerAPI.cpp
@@ -10,10 +10,10 @@
 #include "../Utils/Utils.h"
 #include "Plugins/Process/gdb-remote/ProcessGDBRemoteLog.h"
 #include "lldb/Host/common/NativeProcessProtocol.h"
+#include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/Error.h"
 
 #include <cstring>
-#include <dlfcn.h>
 #include <string>
 #include <type_traits>
 
@@ -144,25 +144,26 @@ WriteInitializationSymbolsToHost(const GPUPluginBreakpointHitArgs &bp_args,
   return Error::success();
 }
 
-static Error WriteConfigurationToLibcuda(void *libcuda, uint32_t pid,
-                                         uint32_t revision, uint32_t session_id,
+static Error WriteConfigurationToLibcuda(llvm::sys::DynamicLibrary &libcuda,
+                                         uint32_t pid, uint32_t revision,
+                                         uint32_t session_id,
                                          StringRef libcuda_library_name) {
   auto *api_client_pid = reinterpret_cast<uint32_t *>(
-      dlsym(libcuda, Symbols::CUDBG_APICLIENT_PID.c_str()));
+      libcuda.getAddressOfSymbol(Symbols::CUDBG_APICLIENT_PID.c_str()));
   if (!api_client_pid)
     return createStringErrorFmt("Failed to find symbol {} in {}",
                                 Symbols::CUDBG_APICLIENT_PID,
                                 libcuda_library_name);
 
   auto *api_client_revision = reinterpret_cast<uint32_t *>(
-      dlsym(libcuda, Symbols::CUDBG_APICLIENT_REVISION.c_str()));
+      libcuda.getAddressOfSymbol(Symbols::CUDBG_APICLIENT_REVISION.c_str()));
   if (!api_client_revision)
     return createStringErrorFmt("Failed to find symbol {} in {}",
                                 Symbols::CUDBG_APICLIENT_REVISION,
                                 libcuda_library_name);
 
   auto *session_id_ptr = reinterpret_cast<uint32_t *>(
-      dlsym(libcuda, Symbols::CUDBG_SESSION_ID.c_str()));
+      libcuda.getAddressOfSymbol(Symbols::CUDBG_SESSION_ID.c_str()));
   if (!session_id_ptr)
     return createStringErrorFmt("Failed to find symbol {} in {}",
                                 Symbols::CUDBG_SESSION_ID,
@@ -177,7 +178,8 @@ static Error WriteConfigurationToLibcuda(void *libcuda, uint32_t pid,
 
 static Error
 WriteInjectionPathToLibcuda(const GPUPluginBreakpointHitArgs &bp_args,
-                            NativeProcessProtocol &linux_process, void *libcuda,
+                            NativeProcessProtocol &linux_process,
+                            llvm::sys::DynamicLibrary &libcuda,
                             StringRef libcuda_library_name) {
   auto write_c_str = [&](const std::string &symbol_name,
                          const char *value) -> Error {
@@ -188,7 +190,7 @@ WriteInjectionPathToLibcuda(const GPUPluginBreakpointHitArgs &bp_args,
     if (Error err = write_c_str(Symbols::CUDBG_INJECTION_PATH, path))
       return err;
     char *injection_path = reinterpret_cast<char *>(
-        dlsym(libcuda, Symbols::CUDBG_INJECTION_PATH.c_str()));
+        libcuda.getAddressOfSymbol(Symbols::CUDBG_INJECTION_PATH.c_str()));
     if (!injection_path)
       return createStringErrorFmt("Failed to find symbol {} in {}",
                                   Symbols::CUDBG_INJECTION_PATH,
@@ -202,11 +204,12 @@ WriteInjectionPathToLibcuda(const GPUPluginBreakpointHitArgs &bp_args,
 // the basis for choosing a mutually-supported revision so the debugger can
 // attach to any driver within its compiled major release.
 static Expected<nvgpu::CudbgApiVersion>
-GetDriverAPIVersion(void *libcuda, StringRef libcuda_library_name) {
+GetDriverAPIVersion(llvm::sys::DynamicLibrary &libcuda,
+                    StringRef libcuda_library_name) {
   using CudbgGetAPIVersionFn =
       CUDBGResult (*)(uint32_t *, uint32_t *, uint32_t *);
   const auto cudbgGetAPIVersion = reinterpret_cast<CudbgGetAPIVersionFn>(
-      dlsym(libcuda, Symbols::CUDBG_GET_API_VERSION.c_str()));
+      libcuda.getAddressOfSymbol(Symbols::CUDBG_GET_API_VERSION.c_str()));
   if (!cudbgGetAPIVersion)
     return createStringErrorFmt("Failed to find symbol {} in {}",
                                 Symbols::CUDBG_GET_API_VERSION,
@@ -223,12 +226,13 @@ GetDriverAPIVersion(void *libcuda, StringRef libcuda_library_name) {
 }
 
 static Expected<CUDBGAPI>
-GetRawAPIInstance(void *libcuda, StringRef libcuda_library_name,
+GetRawAPIInstance(llvm::sys::DynamicLibrary &libcuda,
+                  StringRef libcuda_library_name,
                   const nvgpu::CudbgApiVersion &version) {
   using CudbgGetAPIFn =
       CUDBGResult (*)(uint32_t, uint32_t, uint32_t, CUDBGAPI *);
   const CudbgGetAPIFn cudbgGetAPI = reinterpret_cast<CudbgGetAPIFn>(
-      dlsym(libcuda, Symbols::CUDBG_GET_API.c_str()));
+      libcuda.getAddressOfSymbol(Symbols::CUDBG_GET_API.c_str()));
   if (!cudbgGetAPI)
     return createStringErrorFmt("Failed to find symbol {} in {}",
                                 Symbols::CUDBG_GET_API, libcuda_library_name);
@@ -256,9 +260,13 @@ CUDADebuggerAPI::InitializeImpl(const GPUPluginBreakpointHitArgs &bp_args,
   const uint32_t pid = getpid();
   const uint32_t session_id = 0;
 
-  void *libcuda = dlopen(libcuda_library_name.str().c_str(), RTLD_LAZY);
-  if (!libcuda)
-    return createStringErrorFmt("Failed to dlopen {}", libcuda_library_name);
+  std::string load_error;
+  llvm::sys::DynamicLibrary libcuda =
+      llvm::sys::DynamicLibrary::getPermanentLibrary(
+          libcuda_library_name.str().c_str(), &load_error);
+  if (!libcuda.isValid())
+    return createStringErrorFmt("Failed to load {}: {}", libcuda_library_name,
+                                load_error);
 
   // Discover the driver's supported API version and choose the version to
   // use. We support any driver within our compiled major release; using the

--- a/lldb/tools/lldb-server/Plugins/NVGPU/CUDADebuggerAPI.cpp
+++ b/lldb/tools/lldb-server/Plugins/NVGPU/CUDADebuggerAPI.cpp
@@ -36,6 +36,7 @@ static std::string CUDBG_DEBUGGER_CAPABILITIES =
     STRINGIFY_SYMBOL(CUDBG_DEBUGGER_CAPABILITIES);
 static std::string CUDBG_INJECTION_PATH = "cudbgInjectionPath";
 static std::string CUDBG_GET_API = "cudbgGetAPI";
+static std::string CUDBG_GET_API_VERSION = "cudbgGetAPIVersion";
 static std::string CUDA_INITIALIZATION_SYMBOL =
     CMAKE_NVGPU_INITIALIZATION_SYMBOL;
 } // namespace Symbols
@@ -197,8 +198,33 @@ WriteInjectionPathToLibcuda(const GPUPluginBreakpointHitArgs &bp_args,
   return Error::success();
 }
 
-static Expected<CUDBGAPI> GetRawAPIInstance(void *libcuda,
-                                            StringRef libcuda_library_name) {
+// Query the CUDA debugger API version that the live driver supports. This is
+// the basis for choosing a mutually-supported revision so the debugger can
+// attach to any driver within its compiled major release.
+static Expected<nvgpu::CudbgApiVersion>
+GetDriverAPIVersion(void *libcuda, StringRef libcuda_library_name) {
+  using CudbgGetAPIVersionFn =
+      CUDBGResult (*)(uint32_t *, uint32_t *, uint32_t *);
+  const auto cudbgGetAPIVersion = reinterpret_cast<CudbgGetAPIVersionFn>(
+      dlsym(libcuda, Symbols::CUDBG_GET_API_VERSION.c_str()));
+  if (!cudbgGetAPIVersion)
+    return createStringErrorFmt("Failed to find symbol {} in {}",
+                                Symbols::CUDBG_GET_API_VERSION,
+                                libcuda_library_name);
+
+  nvgpu::CudbgApiVersion version;
+  CUDBGResult res =
+      cudbgGetAPIVersion(&version.major, &version.minor, &version.revision);
+  if (res != CUDBG_SUCCESS)
+    return createStringErrorFmt("The `cudbgGetAPIVersion` call failed. {}",
+                                cudbgGetErrorString(res));
+
+  return version;
+}
+
+static Expected<CUDBGAPI>
+GetRawAPIInstance(void *libcuda, StringRef libcuda_library_name,
+                  const nvgpu::CudbgApiVersion &version) {
   using CudbgGetAPIFn =
       CUDBGResult (*)(uint32_t, uint32_t, uint32_t, CUDBGAPI *);
   const CudbgGetAPIFn cudbgGetAPI = reinterpret_cast<CudbgGetAPIFn>(
@@ -207,10 +233,12 @@ static Expected<CUDBGAPI> GetRawAPIInstance(void *libcuda,
     return createStringErrorFmt("Failed to find symbol {} in {}",
                                 Symbols::CUDBG_GET_API, libcuda_library_name);
 
+  // Request the chosen version (the lesser of the compiled and driver
+  // versions). The driver returns an API table matching the requested
+  // version's ABI.
   CUDBGAPI api;
   CUDBGResult res =
-      cudbgGetAPI(CUDBG_API_VERSION_MAJOR, CUDBG_API_VERSION_MINOR,
-                  CUDBG_API_VERSION_REVISION, &api);
+      cudbgGetAPI(version.major, version.minor, version.revision, &api);
   if (res != CUDBG_SUCCESS)
     return createStringErrorFmt("The `cudbgGetAPI` call failed. {}",
                                 cudbgGetErrorString(res));
@@ -227,15 +255,47 @@ CUDADebuggerAPI::InitializeImpl(const GPUPluginBreakpointHitArgs &bp_args,
 
   const uint32_t pid = getpid();
   const uint32_t session_id = 0;
-  const uint32_t revision = CUDBG_API_VERSION_REVISION;
-
-  if (Error err = WriteInitializationSymbolsToHost(bp_args, linux_process, pid,
-                                                   session_id, revision))
-    return err;
 
   void *libcuda = dlopen(libcuda_library_name.str().c_str(), RTLD_LAZY);
   if (!libcuda)
     return createStringErrorFmt("Failed to dlopen {}", libcuda_library_name);
+
+  // Discover the driver's supported API version and choose the version to
+  // use. We support any driver within our compiled major release; using the
+  // lesser of the compiled and driver versions lets an older in-major driver
+  // still attach (newer-than-driver features are simply unavailable).
+  Expected<nvgpu::CudbgApiVersion> driver_version_or =
+      GetDriverAPIVersion(libcuda, libcuda_library_name);
+  if (!driver_version_or)
+    return driver_version_or.takeError();
+
+  const nvgpu::CudbgApiVersion driver_version = *driver_version_or;
+  const nvgpu::CudbgApiVersion compiled_version =
+      nvgpu::CudbgApiVersion::Compiled();
+
+  if (driver_version.major != compiled_version.major)
+    return createStringErrorFmt(
+        "The CUDA driver debugger API major version ({0}) does not match the "
+        "version this lldb-server was built against ({1}). Cross-major-release "
+        "GPU debugging is not supported; use an lldb-server built against CUDA "
+        "{0}.x.",
+        driver_version.major, compiled_version.major);
+
+  const nvgpu::CudbgApiVersion api_version =
+      driver_version < compiled_version ? driver_version : compiled_version;
+  const uint32_t revision = api_version.revision;
+
+  LLDB_LOG(log,
+           "CUDADebuggerAPI: compiled {0}.{1}.{2}, driver {3}.{4}.{5}, "
+           "using {6}.{7}.{8}",
+           compiled_version.major, compiled_version.minor,
+           compiled_version.revision, driver_version.major,
+           driver_version.minor, driver_version.revision, api_version.major,
+           api_version.minor, api_version.revision);
+
+  if (Error err = WriteInitializationSymbolsToHost(bp_args, linux_process, pid,
+                                                   session_id, revision))
+    return err;
 
   if (Error err = WriteConfigurationToLibcuda(libcuda, pid, revision,
                                               session_id, libcuda_library_name))
@@ -245,11 +305,12 @@ CUDADebuggerAPI::InitializeImpl(const GPUPluginBreakpointHitArgs &bp_args,
                                               libcuda_library_name))
     return err;
 
-  Expected<CUDBGAPI> api_or = GetRawAPIInstance(libcuda, libcuda_library_name);
+  Expected<CUDBGAPI> api_or =
+      GetRawAPIInstance(libcuda, libcuda_library_name, api_version);
   if (!api_or)
     return api_or.takeError();
 
-  CUDADebuggerAPI api(*api_or);
+  CUDADebuggerAPI api(*api_or, api_version);
 
   CUDBGResult res = api->initialize();
   if (res != CUDBG_SUCCESS)

--- a/lldb/tools/lldb-server/Plugins/NVGPU/CUDADebuggerAPI.h
+++ b/lldb/tools/lldb-server/Plugins/NVGPU/CUDADebuggerAPI.h
@@ -11,22 +11,14 @@
 
 #include "cudadebugger.h"
 #include "lldb/Host/common/NativeProcessProtocol.h"
+// Shared single-major version policy: the LLDB_NVGPU_CUDBG_API_* compile-time
+// macros, the single-major static_assert, and the runtime CudbgApiVersion
+// type used to pick a driver-compatible API version.
+#include "lldb/Utility/NVGPU/CUDADebuggerVersion.h"
 
 #include <memory>
 
 namespace lldb_private::lldb_server {
-
-// Verify if the provided version numbers are less than the current CUDA
-// Debugger API version.
-#define IS_CUGDB_API_VERSION_LT(major, minor, revision)                        \
-  (CUDBG_API_VERSION_MAJOR < major ||                                          \
-   (CUDBG_API_VERSION_MAJOR == major && CUDBG_API_VERSION_MINOR < minor) || \
-   (CUDBG_API_VERSION_MAJOR == major && CUDBG_API_VERSION_MINOR == minor && CUDBG_API_VERSION_REVISION < revision))
-
-// Verify if the provided version numbers are greater than or equal to the
-// current CUDA Debugger API version.
-#define IS_CUGDB_API_VERSION_GTE(major, minor, revision)                       \
-  !IS_CUGDB_API_VERSION_LT(major, minor, revision)
 
 /// Custom deleter for CUDBGAPI.
 void CUDBGAPIDeleter(CUDBGAPI api);
@@ -55,13 +47,26 @@ public:
 
   CUDBGAPI GetRawAPI() const { return m_api_up.get(); }
 
+  /// The CUDA debugger API version this session operates at: the lesser of
+  /// this build's compiled version and the live driver's reported version.
+  /// Any driver of the same CUDA major release works -- older OR newer than
+  /// the compiled header; only the major must match (a different major is
+  /// rejected at initialization, see Initialize). Taking the lesser of the
+  /// two just means we never request an entry point the running driver
+  /// doesn't provide. Carried so it can be handed to `ProcessNVGPU` for
+  /// runtime gating of version-specific API calls (see
+  /// `ProcessNVGPU::GetAPIVersion`).
+  nvgpu::CudbgApiVersion GetAPIVersion() const { return m_api_version; }
+
   static GPUBreakpointInfo
   GetInitializationBreakpointInfo(llvm::StringRef library_name);
 
 private:
-  CUDADebuggerAPI(CUDBGAPI api) : m_api_up(api, CUDBGAPIDeleter) {}
+  CUDADebuggerAPI(CUDBGAPI api, nvgpu::CudbgApiVersion api_version)
+      : m_api_up(api, CUDBGAPIDeleter), m_api_version(api_version) {}
 
   std::unique_ptr<const CUDBGAPI_st, decltype(&CUDBGAPIDeleter)> m_api_up;
+  nvgpu::CudbgApiVersion m_api_version;
 
   static llvm::Expected<CUDADebuggerAPI>
   InitializeImpl(const GPUPluginBreakpointHitArgs &bp_args,

--- a/lldb/tools/lldb-server/Plugins/NVGPU/ProcessNVGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/NVGPU/ProcessNVGPU.cpp
@@ -88,6 +88,7 @@ Status ProcessNVGPU::Resume(const ResumeActionList &resume_actions) {
 void ProcessNVGPU::SetDebuggerAPI(CUDADebuggerAPI &api) {
   Log *log = GetLog(GDBRLog::Plugin);
   m_api = api.GetRawAPI();
+  m_api_version = api.GetAPIVersion();
   m_devices = DeviceStateRegistry(*this);
   size_t max_num_threads = m_devices.GetMaxNumSupportedThreads();
   LLDB_LOG(log,

--- a/lldb/tools/lldb-server/Plugins/NVGPU/ProcessNVGPU.h
+++ b/lldb/tools/lldb-server/Plugins/NVGPU/ProcessNVGPU.h
@@ -61,6 +61,13 @@ public:
 
   CUDBGAPI GetDebuggerAPI() const { return m_api; }
 
+  /// The API version this session runs at: the lesser of the compiled and the
+  /// live driver's versions. Gate calls to entry points newer than the
+  /// major's baseline on this -- `if (GetAPIVersion().AtLeast(13, 4, 0))
+  /// api->newCall(...)` -- since a driver older than the compiled header lacks
+  /// those (appended) slots and reading the pointer would be out of bounds.
+  nvgpu::CudbgApiVersion GetAPIVersion() const { return m_api_version; }
+
   /// Resume the GPU, change its state and the state of each thread, then
   /// report the state change to the delegate, which will notify the client.
   ///
@@ -341,6 +348,9 @@ private:
   /// using the class used for CPU processes for this for simplicity.
   ProcessInstanceInfo m_process_info;
   CUDBGAPI m_api;
+  /// API version in use with the live driver, for runtime gating of
+  /// version-specific API calls.
+  nvgpu::CudbgApiVersion m_api_version;
 
   /// The list of all the cubins loaded by the GPU.
   std::vector<GPUDynamicLoaderLibraryInfo> m_all_libraries;

--- a/lldb/tools/lldb-server/Plugins/NVGPU/RegisterContextNVGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/NVGPU/RegisterContextNVGPU.cpp
@@ -38,17 +38,22 @@ CUDBGAPI RegisterContextNVGPU::GetDebuggerAPI() {
 static void ReadRegularRegistersFromDevice(CUDBGAPI api, WarpState &warp_state,
                                            const ThreadCoords &thread_coords,
                                            ThreadRegistersWithValidity &regs) {
-#if IS_CUGDB_API_VERSION_LT(13, 2, 100)
   uint32_t num_regs_read = warp_state.GetCurrentNumRegularRegisters();
-
-  CUDBGResult res = api->readRegisterRange(
+  // Always call the stable 7-arg entry point. It lives at a fixed offset in
+  // every in-major driver's API table, so it works regardless of the
+  // (possibly older) driver we attached to -- no runtime version check is
+  // needed. CTK 13.2 (CUDBG API revision > 167) renamed it to
+  // readRegisterRange60 and appended a new 8-arg readRegisterRange variant we
+  // don't use; select the right name at compile time. Mirrors cuda-gdb's
+  // cuda_debugapi::read_register_range.
+#if LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(168)
+  CUDBGResult res = api->readRegisterRange60(
       thread_coords.dev_id, thread_coords.sm_id, thread_coords.warp_id,
       thread_coords.thread_id, 0, num_regs_read, regs.val.regular);
 #else
-  uint32_t num_regs_read = 0;
   CUDBGResult res = api->readRegisterRange(
       thread_coords.dev_id, thread_coords.sm_id, thread_coords.warp_id,
-      thread_coords.thread_id, 0, kNumRRegs, regs.val.regular, &num_regs_read);
+      thread_coords.thread_id, 0, num_regs_read, regs.val.regular);
 #endif
   if (res != CUDBG_SUCCESS)
     logAndReportFatalError("RegisterContextNVGPU::ReadAllRegsFromDevice(). "

--- a/lldb/tools/lldb-server/Plugins/NVGPU/RegisterContextNVGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/NVGPU/RegisterContextNVGPU.cpp
@@ -44,8 +44,7 @@ static void ReadRegularRegistersFromDevice(CUDBGAPI api, WarpState &warp_state,
   // (possibly older) driver we attached to -- no runtime version check is
   // needed. CTK 13.2 (CUDBG API revision > 167) renamed it to
   // readRegisterRange60 and appended a new 8-arg readRegisterRange variant we
-  // don't use; select the right name at compile time. Mirrors cuda-gdb's
-  // cuda_debugapi::read_register_range.
+  // don't use; select the right name at compile time.
 #if LLDB_NVGPU_CUDBG_API_REV_AT_LEAST(168)
   CUDBGResult res = api->readRegisterRange60(
       thread_coords.dev_id, thread_coords.sm_id, thread_coords.warp_id,


### PR DESCRIPTION
This commit introduces a new header file, `CUDADebuggerVersion.h`, which provides version compatibility helpers for the CUDA debugger API. It ensures that the NVGPU plugins operate correctly within the same CUDA major release, enforcing a single-major compatibility policy.

Additionally, the `ObjectFileELF` class is updated with a new method, `GetNVGPUMetadata`, to extract metadata from the NVGPU corefile, allowing for better diagnostics regarding the producing driver version. The `ProcessNVGPUCore` class is enhanced to log the producer information and issue warnings for cross-major-release coredumps, ensuring that users are informed of potential compatibility issues.

Standardize runtime compatability checks to gate against differing cudadebugger.h and encountered runtime driver versions.