### PR TITLE
[lldb] Preserve object slices when replacing modules

### DIFF
--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -263,11 +263,14 @@ void ModuleList::ReplaceEquivalent(
     std::lock_guard<std::recursive_mutex> guard(m_modules_mutex);
 
     // First remove any equivalent modules. Equivalent modules are modules
-    // whose path, platform path and architecture match.
+    // whose path, platform path, architecture and object slice match.
     ModuleSpec equivalent_module_spec(module_sp->GetFileSpec(),
                                       module_sp->GetArchitecture());
     equivalent_module_spec.GetPlatformFileSpec() =
         module_sp->GetPlatformFileSpec();
+    equivalent_module_spec.GetObjectName() = module_sp->GetObjectName();
+    equivalent_module_spec.SetObjectOffset(module_sp->GetObjectOffset());
+    equivalent_module_spec.SetObjectSize(module_sp->GetObjectSize());
 
     size_t idx = 0;
     while (idx < m_modules.size()) {
@@ -929,11 +932,14 @@ private:
       return;
 
     // First remove any equivalent modules. Equivalent modules are modules
-    // whose path, platform path and architecture match.
+    // whose path, platform path, architecture and object slice match.
     ModuleSpec equivalent_module_spec(module_sp->GetFileSpec(),
                                       module_sp->GetArchitecture());
     equivalent_module_spec.GetPlatformFileSpec() =
         module_sp->GetPlatformFileSpec();
+    equivalent_module_spec.GetObjectName() = module_sp->GetObjectName();
+    equivalent_module_spec.SetObjectOffset(module_sp->GetObjectOffset());
+    equivalent_module_spec.SetObjectSize(module_sp->GetObjectSize());
 
     llvm::SmallVectorImpl<ModuleSP> &vec = it->second;
     llvm::erase_if(vec, [&equivalent_module_spec](ModuleSP &element) {

--- a/lldb/test/API/gpu/amd/multiple-code-objects/Makefile
+++ b/lldb/test/API/gpu/amd/multiple-code-objects/Makefile
@@ -1,0 +1,3 @@
+HIP_SOURCES := main.hip first_kernel.hip second_kernel.hip
+
+include Makefile.rules

--- a/lldb/test/API/gpu/amd/multiple-code-objects/TestMultipleCodeObjectsAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/multiple-code-objects/TestMultipleCodeObjectsAmdGpuPlugin.py
@@ -1,0 +1,125 @@
+"""
+Tests for live AMDGPU processes with multiple code objects.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from amdgpu_testcase import *
+from lldbsuite.test.lldbtest import *
+
+
+class MultipleCodeObjectsAmdGpuTestCase(AmdGpuTestCaseBase):
+    def run_to_gpu_trap(self):
+        self.build()
+
+        target = self.createTestTarget()
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertTrue(process.IsValid(), PROCESS_IS_VALID)
+        self.assertTrue(self.gpu_target.IsValid(), "GPU target should be valid")
+        self.assertTrue(self.gpu_process.IsValid(), "GPU process should be valid")
+
+        self.setAsync(True)
+        listener = self.dbg.GetListener()
+
+        self.select_gpu()
+        error = self.gpu_process.Continue()
+        self.assertSuccess(error, "continue GPU process")
+        lldbutil.expect_state_changes(
+            self, listener, self.gpu_process, [lldb.eStateRunning]
+        )
+
+        self.select_cpu()
+        error = self.cpu_process.Continue()
+        self.assertSuccess(error, "continue CPU process")
+        lldbutil.expect_state_changes(
+            self, listener, self.cpu_process, [lldb.eStateRunning]
+        )
+
+        lldbutil.expect_state_changes(
+            self, listener, self.gpu_process, [lldb.eStateStopped]
+        )
+
+    def get_frame_names(self, frame):
+        names = []
+
+        function_name = frame.GetFunctionName()
+        if function_name:
+            names.append(function_name)
+
+        display_function_name = frame.GetDisplayFunctionName()
+        if display_function_name:
+            names.append(display_function_name)
+
+        function = frame.GetFunction()
+        if function.IsValid():
+            name = function.GetName()
+            if name:
+                names.append(name)
+
+        symbol = frame.GetSymbol()
+        if symbol.IsValid():
+            name = symbol.GetName()
+            if name:
+                names.append(name)
+
+        return names
+
+    def test_multiple_code_object_modules_are_preserved(self):
+        self.run_to_gpu_trap()
+        self.select_gpu()
+        gpu_target = self.dbg.GetSelectedTarget()
+        self.assertTrue(gpu_target.IsValid(), "selected GPU target should be valid")
+
+        modules = []
+        file_backed_code_objects = []
+        memory_backed_code_objects = []
+        module_count = gpu_target.GetNumModules()
+        for idx in range(module_count):
+            module = gpu_target.GetModuleAtIndex(idx)
+            self.assertTrue(module.IsValid(), "module %d should be valid" % idx)
+
+            filename = module.GetFileSpec().GetFilename()
+            description = str(module)
+            modules.append(description)
+            if filename == "a.out":
+                file_backed_code_objects.append(module)
+            if "amd_memory_kernel[" in description:
+                memory_backed_code_objects.append(module)
+
+        self.assertGreaterEqual(
+            module_count,
+            2,
+            "expected multiple GPU code object modules; got modules: "
+            + repr(modules),
+        )
+        self.assertTrue(
+            file_backed_code_objects,
+            "expected a file-backed GPU code object module; got modules: "
+            + repr(modules),
+        )
+        self.assertTrue(
+            memory_backed_code_objects,
+            "expected a memory-backed GPU code object module; got modules: "
+            + repr(modules),
+        )
+
+        thread = self.gpu_process.GetSelectedThread()
+        self.assertTrue(thread.IsValid(), "selected GPU thread should be valid")
+        self.assertGreater(thread.GetNumFrames(), 0, "GPU thread should have frames")
+
+        frame_names = []
+        found_second_kernel = False
+        for idx in range(thread.GetNumFrames()):
+            frame = thread.GetFrameAtIndex(idx)
+            self.assertTrue(frame.IsValid(), "frame %d should be valid" % idx)
+
+            names = self.get_frame_names(frame)
+            frame_names.append((idx, names))
+            if any("second_code_object_kernel" in name for name in names):
+                found_second_kernel = True
+
+        self.assertTrue(
+            found_second_kernel,
+            "expected GPU frames to include second_code_object_kernel; got frame names: "
+            + repr(frame_names),
+        )

--- a/lldb/test/API/gpu/amd/multiple-code-objects/first_kernel.hip
+++ b/lldb/test/API/gpu/amd/multiple-code-objects/first_kernel.hip
@@ -1,0 +1,10 @@
+#include <hip/hip_runtime.h>
+
+static __global__ void first_code_object_kernel(int *value) {
+  if (threadIdx.x == 0 && blockIdx.x == 0)
+    *value = 1;
+}
+
+extern "C" void launch_first_code_object_kernel(int *value) {
+  first_code_object_kernel<<<dim3(1), dim3(1)>>>(value);
+}

--- a/lldb/test/API/gpu/amd/multiple-code-objects/main.hip
+++ b/lldb/test/API/gpu/amd/multiple-code-objects/main.hip
@@ -1,0 +1,31 @@
+#include <hip/hip_runtime.h>
+
+#include <cstdlib>
+#include <iostream>
+
+#define HIP_CHECK(condition)                                                   \
+  do {                                                                         \
+    hipError_t error = condition;                                              \
+    if (error != hipSuccess) {                                                 \
+      std::cerr << "HIP error: " << hipGetErrorString(error) << std::endl;     \
+      std::exit(1);                                                            \
+    }                                                                          \
+  } while (false)
+
+extern "C" void launch_first_code_object_kernel(int *value);
+extern "C" void launch_second_code_object_kernel(int *value);
+
+int main() {
+  int *d_value = nullptr;
+  HIP_CHECK(hipMalloc(&d_value, sizeof(int)));
+  HIP_CHECK(hipMemset(d_value, 0, sizeof(int)));
+
+  launch_first_code_object_kernel(d_value);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  launch_second_code_object_kernel(d_value);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  HIP_CHECK(hipFree(d_value));
+  return 0;
+}

--- a/lldb/test/API/gpu/amd/multiple-code-objects/second_kernel.hip
+++ b/lldb/test/API/gpu/amd/multiple-code-objects/second_kernel.hip
@@ -1,0 +1,10 @@
+#include <hip/hip_runtime.h>
+
+static __global__ void second_code_object_kernel(int *value) {
+  if (threadIdx.x == 0 && blockIdx.x == 0 && *value == 1)
+    __builtin_trap();
+}
+
+extern "C" void launch_second_code_object_kernel(int *value) {
+  second_code_object_kernel<<<dim3(1), dim3(1)>>>(value);
+}

--- a/lldb/unittests/Core/ModuleListTest.cpp
+++ b/lldb/unittests/Core/ModuleListTest.cpp
@@ -13,6 +13,7 @@
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Utility/ArchSpec.h"
+#include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/UUID.h"
 
 #include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
@@ -175,4 +176,70 @@ Sections:
       }
     }
   }
+}
+
+TEST(ModuleListTest, ReplaceEquivalentKeepsDifferentObjectSlices) {
+  SubsystemRAII<FileSystem, ObjectFileELF> subsystems;
+
+  auto DummyFile = TestFile::fromYaml(R"(
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x0000000000000010
+...
+)");
+  ASSERT_THAT_EXPECTED(DummyFile, llvm::Succeeded());
+
+  auto SliceFile = TestFile::fromYaml(R"(
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x0000000000000010
+...
+)");
+  ASSERT_THAT_EXPECTED(SliceFile, llvm::Succeeded());
+
+  ModuleSP dummy_module;
+  bool did_create = false;
+  Status error = ModuleList::GetSharedModule(
+      DummyFile->moduleSpec(), dummy_module, nullptr, &did_create, false);
+  ASSERT_TRUE(error.Success());
+  ASSERT_NE(dummy_module, nullptr);
+  ASSERT_NE(dummy_module->GetObjectFile(), nullptr);
+
+  ModuleSpec slice_spec = SliceFile->moduleSpec();
+  const llvm::sys::TimePoint<> object_mod_time;
+  ModuleSP first_module = std::make_shared<Module>(
+      slice_spec.GetFileSpec(), slice_spec.GetArchitecture(),
+      ConstString("libwithslices.so[0x1000-0x1200)"), 0x1000, object_mod_time);
+  ModuleSP second_module = std::make_shared<Module>(
+      slice_spec.GetFileSpec(), slice_spec.GetArchitecture(),
+      ConstString("libwithslices.so[0x2000-0x2300)"), 0x2000, object_mod_time);
+
+  ASSERT_NE(first_module->GetObjectName(), second_module->GetObjectName());
+  ASSERT_NE(first_module->GetObjectOffset(), second_module->GetObjectOffset());
+
+  ModuleList module_list;
+  module_list.Append(dummy_module);
+  module_list.Append(first_module);
+  module_list.ReplaceEquivalent(second_module);
+
+  EXPECT_EQ(module_list.GetSize(), 3u);
+  EXPECT_EQ(module_list.GetModuleAtIndex(0), dummy_module);
+  EXPECT_EQ(module_list.GetModuleAtIndex(1), first_module);
+  EXPECT_EQ(module_list.GetModuleAtIndex(2), second_module);
 }


### PR DESCRIPTION
GPU core files can report multiple AMDGPU code objects embedded in the same host shared library. These modules share the same file path and architecture, but they are different object-file slices with different offsets, sizes, UUIDs, and load addresses.

When replacing an equivalent module, LLDB built the lookup spec without the object slice information from the existing module. That made the lookup broad enough to match every code-object slice from the same file and architecture. A later slice could replace an earlier one while the target still had section load entries referring to sections from the removed module. During stack unwinding, resolving a load address through those stale sections could hit the `Section::ResolveContainedAddress` assertion because the section no longer had an owning module. We have seen crash from this.

To fix this issue, this PR preserve the existing module's object name, object offset, and object size when constructing the equivalent-module lookup spec. This keeps separate embedded code-object slices distinct and prevents unrelated slices from replacing each other.

### Test plan:
- Two new tests (ReplaceEquivalentKeepsDifferentObjectSlices and MultipleCodeObjectsAmdGpuTestCase) are added
- ./bin/llvm-lit -av /home/jeffreytan/clayborg/llvm-project/lldb/test/API/gpu/amd/
- No regression from ninja check-lldb