### PR TITLE
[LLDB][AMDGPU] Fix symbolized GPU backtraces for cores with multiple code objects

### DIFF
--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -263,11 +263,16 @@ void ModuleList::ReplaceEquivalent(
     std::lock_guard<std::recursive_mutex> guard(m_modules_mutex);
 
     // First remove any equivalent modules. Equivalent modules are modules
-    // whose path, platform path and architecture match.
+    // whose path, platform path, architecture and object slice match. Matching
+    // the object slice (name/offset/size) keeps code-object slices that share
+    // one container file path from collapsing into each other.
     ModuleSpec equivalent_module_spec(module_sp->GetFileSpec(),
                                       module_sp->GetArchitecture());
     equivalent_module_spec.GetPlatformFileSpec() =
         module_sp->GetPlatformFileSpec();
+    equivalent_module_spec.GetObjectName() = module_sp->GetObjectName();
+    equivalent_module_spec.SetObjectOffset(module_sp->GetObjectOffset());
+    equivalent_module_spec.SetObjectSize(module_sp->GetObjectSize());
 
     size_t idx = 0;
     while (idx < m_modules.size()) {
@@ -929,11 +934,16 @@ private:
       return;
 
     // First remove any equivalent modules. Equivalent modules are modules
-    // whose path, platform path and architecture match.
+    // whose path, platform path, architecture and object slice match. Matching
+    // the object slice (name/offset/size) keeps code-object slices that share
+    // one container file path from collapsing into each other.
     ModuleSpec equivalent_module_spec(module_sp->GetFileSpec(),
                                       module_sp->GetArchitecture());
     equivalent_module_spec.GetPlatformFileSpec() =
         module_sp->GetPlatformFileSpec();
+    equivalent_module_spec.GetObjectName() = module_sp->GetObjectName();
+    equivalent_module_spec.SetObjectOffset(module_sp->GetObjectOffset());
+    equivalent_module_spec.SetObjectSize(module_sp->GetObjectSize());
 
     llvm::SmallVectorImpl<ModuleSP> &vec = it->second;
     llvm::erase_if(vec, [&equivalent_module_spec](ModuleSP &element) {

--- a/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
@@ -672,8 +672,20 @@ bool ProcessAmdGpuCore::DoUpdateThreadList(ThreadList &old_thread_list,
     return ret;
 
   for (size_t i = 0; i < count; ++i) {
+    // Use the wave's own architecture, not the process-wide one: a process can
+    // run code objects of different architectures, and amd-dbgapi keys register
+    // ids by architecture. Reading a register with a register id from a
+    // mismatched architecture fails with INVALID_ARGUMENT_COMPATIBILITY,
+    // leaving the wave with an invalid PC.
+    amd_dbgapi_architecture_id_t wave_arch = m_architecture_id;
+    amd_dbgapi_architecture_id_t queried_arch{0};
+    if (amd_dbgapi_wave_get_info(wave_list[i], AMD_DBGAPI_WAVE_INFO_ARCHITECTURE,
+                                 sizeof(queried_arch),
+                                 &queried_arch) == AMD_DBGAPI_STATUS_SUCCESS)
+      wave_arch = queried_arch;
+
     auto thread = std::make_unique<ThreadAMDGPU>(
-        *this, m_architecture_id, wave_list[i].handle, wave_list[i]);
+        *this, wave_arch, wave_list[i].handle, wave_list[i]);
     new_thread_list.AddThread(std::move(thread));
   }
 

--- a/lldb/test/API/gpu/amd/core-multi-codeobj/Makefile
+++ b/lldb/test/API/gpu/amd/core-multi-codeobj/Makefile
@@ -1,0 +1,2 @@
+HIP_SOURCES = koa.hip kob.hip main.hip
+include Makefile.rules

--- a/lldb/test/API/gpu/amd/core-multi-codeobj/TestAmdGpuCoreMultiCodeObject.py
+++ b/lldb/test/API/gpu/amd/core-multi-codeobj/TestAmdGpuCoreMultiCodeObject.py
@@ -1,0 +1,41 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Multiple GPU code objects embedded in one binary (sharing a FileSpec but at
+different object-file slices) must each load as a distinct module, with symbols,
+and unwinding must not crash."""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.tools.gpu.amdgpu_core_testbase import AmdGpuCoreTestBase
+
+
+class TestAmdGpuCoreMultiCodeObject(AmdGpuCoreTestBase):
+    HIP_SOURCE = "kob.hip"
+    GPU_BREAKPOINT_PATTERN = "// BETA BREAKPOINT"
+
+    @skipIfRemote
+    def test_multiple_code_objects_kept_distinct(self):
+        gpu_target, gpu_process = self.load_core()
+
+        # Both code objects' modules and symbols must survive, not just one.
+        aout_modules = 0
+        alpha_found = 0
+        beta_found = 0
+        for i in range(gpu_target.GetNumModules()):
+            module = gpu_target.GetModuleAtIndex(i)
+            if "a.out" not in (module.GetFileSpec().GetFilename() or ""):
+                continue
+            aout_modules += 1
+            alpha_found += module.FindSymbols("kernel_alpha").GetSize()
+            beta_found += module.FindSymbols("kernel_beta").GetSize()
+
+        self.assertGreaterEqual(
+            aout_modules, 2, "GPU code objects collapsed into one module"
+        )
+        self.assertGreater(alpha_found, 0, "kernel_alpha symbol missing")
+        self.assertGreater(beta_found, 0, "kernel_beta symbol missing")
+
+        # Unwinding the stopped wave must not crash and must be symbolized.
+        frame = gpu_process.GetSelectedThread().GetFrameAtIndex(0)
+        self.assertTrue(frame.IsValid())
+        self.assertIn("kernel_beta", frame.GetFunctionName() or "")

--- a/lldb/test/API/gpu/amd/core-multi-codeobj/koa.hip
+++ b/lldb/test/API/gpu/amd/core-multi-codeobj/koa.hip
@@ -1,0 +1,11 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <hip/hip_runtime.h>
+
+// Own translation unit -> its own GPU code object in a.out.
+__global__ void kernel_alpha(int *o) {
+  int i = threadIdx.x;
+  o[i] = i * 2;
+}
+
+void launch_alpha(int *d) { kernel_alpha<<<1, 32>>>(d); }

--- a/lldb/test/API/gpu/amd/core-multi-codeobj/kob.hip
+++ b/lldb/test/API/gpu/amd/core-multi-codeobj/kob.hip
@@ -1,0 +1,14 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <hip/hip_runtime.h>
+
+// Second translation unit -> a second code object at a different offset in the
+// same a.out (same FileSpec, different slice).
+__global__ void kernel_beta(int *o, int n) {
+  int i = threadIdx.x;
+  if (i < n) {
+    o[i] = i + 1000; // BETA BREAKPOINT
+  }
+}
+
+void launch_beta(int *d, int n) { kernel_beta<<<1, 32>>>(d, n); }

--- a/lldb/test/API/gpu/amd/core-multi-codeobj/main.hip
+++ b/lldb/test/API/gpu/amd/core-multi-codeobj/main.hip
@@ -1,0 +1,19 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+void launch_alpha(int *d);
+void launch_beta(int *d, int n);
+
+int main() {
+  int *da, *db;
+  hipMalloc(&da, 32 * sizeof(int));
+  hipMalloc(&db, 32 * sizeof(int));
+  launch_alpha(da); // loads code object A
+  hipDeviceSynchronize();
+  launch_beta(db, 32); // loads code object B; breakpoint fires inside it
+  hipDeviceSynchronize();
+  printf("done\n");
+  return 0;
+}


### PR DESCRIPTION
Debugging a merged AMD GPU coredump where one host shared library embeds many device code objects, the crashing GPU frame couldn't be symbolized. 

rocgdb showed it fine:
```
#0 process_all_indices_small_Ls<…72u,4u,15u,64u…> @ libdeeplearning_…_gpu.so
```

roclldb instead either aborted during bt, or returned degenerate AMD GPU Thread waves with `pc=0xffffffffffffffff` and no symbols.

A GPU backtrace frame needs two things: the PC and the name for that PC (a symbol from the code object's section, which is embedded in the host .so's `.hip_fatbin`). 

This PR is fixing two separate bugs that made it break..

**The first issue:**
a single `.so` embeds many GPU code objects at different file offsets, same on-disk path, different object-file slice. `ModuleList::ReplaceEquivalent` compared only path + arch, so loading code object 2 was treated as "a newer build of the same library" and evicted 1. The evicted module was freed while its sections were still registered at a load address, so resolving any frame PC touched a broken section.

`ReplaceEquivalent` now skips the equivalence scan entirely for modules that are a slice of a container file (an object-file offset/size/name is set, e.g. GPU code objects embedded in one .so, or archive members). Such slices are never a newer "version" of another module, so they're appended and kept as separate modules instead of replacing each other. Whole-file modules are unchanged.

**The second issue:**

The issue was that the PC is read through `amd-dbgapi` with an architecture-scoped register id. The plugin used the process-wide architecture for every wave, but a process can run code objects of different architectures. Reading the PC register with a register id from a mismatched architecture is rejected, so the wave was left with an invalid PC and no frame to symbolize.

I noticed that when during the load, the log reported the stopped wave and its PC: `WAVE_STOP … pc=0x7f27977a23c8` but when I asked for the pc the `amd_dbgapi_wave_register_exists(pc)` returned `-7 = INVALID_ARGUMENT_COMPATIBILITY` ("this register doesn't belong to this wave's architecture"). lldb then fell back to `pc = 0xffffffffffffffff`.
So the mismatch was `gfx942` (specialized) vs `gfx9-4-generic` (generic).

The fix is to query each wave's own architecture via `AMD_DBGAPI_WAVE_INFO_ARCHITECTURE` and build that wave's register context from it. 

Also, created a test that builds one binary with two kernels in separate translation units (so they become two GPU code objects at different offsets in the same .so).