### PR TITLE
[lldb][AMDGPU] Select exception wave when loading core files

### DIFF
--- a/lldb/include/lldb/Utility/AmdGpuStopReason.h
+++ b/lldb/include/lldb/Utility/AmdGpuStopReason.h
@@ -46,10 +46,9 @@ GetLldbStopReasonForDbgApiStopReason(amd_dbgapi_wave_stop_reasons_t reason,
     return lldb::StopReason::eStopReasonException;
   };
 
-  // If none of the bits are set, then we explicitly stopped the wave with
-  // a call to `amd_dbgapi_wave_stop`.
+  // If none of the bits are set, the wave has no actionable stop reason.
   if (reason == AMD_DBGAPI_WAVE_STOP_REASON_NONE)
-    return lldb::StopReason::eStopReasonInterrupt;
+    return lldb::StopReason::eStopReasonNone;
 
   if (reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_INPUT_DENORMAL)
     return make_exception("Floating-point input denormal");

--- a/lldb/source/Plugins/Process/amdgpu-core/ThreadAMDGPU.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ThreadAMDGPU.cpp
@@ -96,6 +96,8 @@ bool ThreadAMDGPU::CalculateStopInfo() {
   case lldb::eStopReasonInterrupt:
     SetStopInfo(StopInfo::CreateStopReasonWithSignal(*this, SIGSTOP));
     break;
+  case lldb::eStopReasonNone:
+    return false;
   default:
     // No recognized stop reason — match rocgdb's GDB_SIGNAL_0 fallback.
     SetStopInfo(StopInfo::CreateStopReasonWithSignal(*this, 0));

--- a/lldb/test/API/gpu/amd/core-exception/TestAmdGpuCoreException.py
+++ b/lldb/test/API/gpu/amd/core-exception/TestAmdGpuCoreException.py
@@ -95,3 +95,62 @@ class TestAmdGpuCoreException(AmdGpuCoreTestBase):
             f"Exception description should contain 'Memory access violation', "
             f"got: '{stop_description}'",
         )
+
+    @skipIfRemote
+    def test_selected_thread_is_memory_violation(self):
+        """Verify core loading selects the GPU exception thread."""
+        gpu_target, gpu_process = self.load_core()
+
+        first_thread = gpu_process.GetThreadAtIndex(0)
+        self.assertTrue(first_thread.IsValid(), "First GPU thread should be valid")
+        self.assertNotEqual(
+            first_thread.GetStopReason(),
+            lldb.eStopReasonException,
+            "Test fixture should list a non-exception GPU thread first; "
+            "otherwise this test can pass without exercising selected-thread "
+            "behavior",
+        )
+
+        selected_thread = gpu_process.GetSelectedThread()
+        self.assertTrue(
+            selected_thread.IsValid(), "Selected GPU thread should be valid"
+        )
+        self.assertNotEqual(
+            selected_thread.GetThreadID(),
+            first_thread.GetThreadID(),
+            "Selected GPU thread should not be the first listed non-exception "
+            "thread",
+        )
+        self.assertEqual(
+            selected_thread.GetStopReason(),
+            lldb.eStopReasonException,
+            "Selected GPU thread should have an exception stop reason",
+        )
+
+        stop_description = selected_thread.GetStopDescription(256)
+        self.assertIn(
+            "Memory access violation",
+            stop_description,
+            f"Selected GPU thread should report 'Memory access violation', "
+            f"got: '{stop_description}'",
+        )
+
+    @skipIfRemote
+    def test_non_stopped_wave_has_no_stop_reason(self):
+        """Verify a wave without a stop event does not report signal 0."""
+        gpu_target, gpu_process = self.load_core()
+
+        first_thread = gpu_process.GetThreadAtIndex(0)
+        self.assertTrue(first_thread.IsValid(), "First GPU thread should be valid")
+        self.assertEqual(
+            first_thread.GetStopReason(),
+            lldb.eStopReasonNone,
+            "Non-stopped GPU thread should not report a stop reason",
+        )
+
+        stop_description = first_thread.GetStopDescription(256)
+        self.assertTrue(
+            stop_description is None or stop_description == "",
+            f"Non-stopped GPU thread should not report a stop description, "
+            f"got: '{stop_description}'",
+        )

--- a/lldb/test/API/gpu/amd/core-exception/exception_core.hip
+++ b/lldb/test/API/gpu/amd/core-exception/exception_core.hip
@@ -14,12 +14,29 @@ constexpr int error_exit_code = -1;
     }                                                                     \
   }
 
-// Kernel that performs an out-of-bounds write to trigger a memory violation.
-__global__ void memory_violation_kernel(int *buf, size_t size) {
+// LLDB lists the later wave first for this core. Keep that later wave stopped
+// normally while an earlier wave triggers the memory violation, so default
+// first-thread selection is not enough to pass the selected-thread test.
+__global__ void memory_violation_kernel(int *buf, unsigned int *ready,
+                                        unsigned int *keep_alive, size_t size) {
   unsigned int tid = threadIdx.x + blockIdx.x * blockDim.x;
-  if (tid == 0) {
+
+  bool faulting_block = blockIdx.x == 0;
+  if (!faulting_block && threadIdx.x == 0) {
+    atomicAdd(ready, 1u);
+  }
+
+  if (faulting_block && threadIdx.x == 0) {
+    while (atomicAdd(ready, 0u) < gridDim.x - 1) {
+    }
     buf[size * 1024 * 1024] = 42; // GPU EXCEPTION
   }
+
+  if (!faulting_block) {
+    while (atomicAdd(keep_alive, 0u) == 0) {
+    }
+  }
+
   if (tid < size) {
     buf[tid] = tid; // GPU BREAKPOINT
   }
@@ -30,18 +47,26 @@ int main() {
   const size_t buffer_size = num_threads * sizeof(int);
 
   int *d_buf;
+  unsigned int *d_ready;
+  unsigned int *d_keep_alive;
   HIP_CHECK(hipMalloc(&d_buf, buffer_size));
+  HIP_CHECK(hipMalloc(&d_ready, sizeof(*d_ready)));
+  HIP_CHECK(hipMalloc(&d_keep_alive, sizeof(*d_keep_alive)));
+  HIP_CHECK(hipMemset(d_ready, 0, sizeof(*d_ready)));
+  HIP_CHECK(hipMemset(d_keep_alive, 0, sizeof(*d_keep_alive)));
 
   printf("Launching kernel...\n"); // CPU BREAKPOINT - BEFORE LAUNCH
 
-  memory_violation_kernel<<<dim3(1), dim3(num_threads), 0,
-                            hipStreamDefault>>>(d_buf, num_threads);
+  memory_violation_kernel<<<dim3(2), dim3(num_threads), 0, hipStreamDefault>>>(
+      d_buf, d_ready, d_keep_alive, num_threads);
 
   HIP_CHECK(hipDeviceSynchronize());
 
   printf("Kernel finished.\n");
 
   HIP_CHECK(hipFree(d_buf));
+  HIP_CHECK(hipFree(d_ready));
+  HIP_CHECK(hipFree(d_keep_alive));
 
   return 0;
 }


### PR DESCRIPTION
Select the GPU wave with an actionable core stop event when loading AMDGPU core files, and add a regression test that fails if LLDB keeps the first listed non-exception wave selected.

This follows how GDB implemented this in https://github.com/ROCm/ROCgdb/blob/dc476213177aefacc15ca3dbb4633a3b2215a31d/gdb/amd-dbgapi-target.c#L2518-L2540. Basically we are selecting the last valid wave from the process_event_queue. The ordering of the queue seem to be deterministic from the core tested.


Manually tested on a production core to match the GDB selected wave.

lit testing
```
[chenlii@devgpu017.cco5 ~/llvm-sand/external/llvm-project (chenlii/pr106-pr108-stack)]$ PATH=/tmp/rocgdb-wrapper:$PATH   build/Debug/bin/llvm-lit -a     --param 'dotest-args=--compiler /opt/llvm/bin/clang'     lldb/test/API/gpu/amd/core-exception/TestAmdGpuCoreException.py
-- Testing: 1 tests, 1 workers --
PASS: lldb-api :: gpu/amd/core-exception/TestAmdGpuCoreException.py (1 of 1)
Script:
--
/home/chenlii/llvm-sand/infrastructure/toolchain/build/tools/sand/python_tester/python_tester_wrapper /home/chenlii/llvm-sand/external/llvm-project/lldb/test/API/dotest.py -u CXXFLAGS -u CFLAGS --env LLVM_LIBS_DIR=/home/chenlii/llvm-sand/external/llvm-project/build/Debug/./lib --env LLVM_INCLUDE_DIR=/home/chenlii/llvm-sand/external/llvm-project/build/Debug/include --env LLVM_TOOLS_DIR=/home/chenlii/llvm-sand/external/llvm-project/build/Debug/./bin --libcxx-include-dir /home/chenlii/llvm-sand/external/llvm-project/build/Debug/include/c++/v1 --libcxx-include-target-dir /home/chenlii/llvm-sand/external/llvm-project/build/Debug/include/x86_64-unknown-linux-gnu/c++/v1 --libcxx-library-dir /home/chenlii/llvm-sand/external/llvm-project/build/Debug/./lib/x86_64-unknown-linux-gnu --arch x86_64 --build-dir /home/chenlii/llvm-sand/external/llvm-project/build/Debug/lldb-test-build.noindex --lldb-module-cache-dir /home/chenlii/llvm-sand/external/llvm-project/build/Debug/lldb-test-build.noindex/module-cache-lldb/lldb-api --clang-module-cache-dir /home/chenlii/llvm-sand/external/llvm-project/build/Debug/lldb-test-build.noindex/module-cache-clang/lldb-api --executable /home/chenlii/llvm-sand/external/llvm-project/build/Debug/./bin/lldb --compiler /home/chenlii/llvm-sand/external/llvm-project/build/Debug/./bin/clang --hipcc-path /usr/local/fbcode/platform010/lib/rocm-6.4.0/bin/hipcc --dsymutil /home/chenlii/llvm-sand/external/llvm-project/build/Debug/./bin/dsymutil --make /usr/bin/gmake --llvm-tools-dir /home/chenlii/llvm-sand/external/llvm-project/build/Debug/./bin --lldb-obj-root /home/chenlii/llvm-sand/external/llvm-project/build/Debug/tools/lldb --lldb-libs-dir /home/chenlii/llvm-sand/external/llvm-project/build/Debug/./lib --cmake-build-type Debug --enable-plugin lldb-amdgpu --compiler /opt/llvm/bin/clang /home/chenlii/llvm-sand/external/llvm-project/lldb/test/API/gpu/amd/core-exception -p TestAmdGpuCoreException.py
--
Exit Code: 0

Command Output (stdout):
--
lldb version 22.0.0git (https://github.com/clayborg/llvm-project.git revision 120de5e4133d4b8acaed79e215c5c341d4ad206f)
  clang revision 120de5e4133d4b8acaed79e215c5c341d4ad206f
  llvm revision 120de5e4133d4b8acaed79e215c5c341d4ad206f
Skipping the following test categories: libc++, msvcstl, dsym, pdb, gmodules, debugserver, objc

--
Command Output (stderr):
--
PASS: LLDB (/opt/llvm/bin/clang-x86_64) :: test_core_has_gpu_waves (TestAmdGpuCoreException.TestAmdGpuCoreException.test_core_has_gpu_waves)
PASS: LLDB (/opt/llvm/bin/clang-x86_64) :: test_exception_stop_reason (TestAmdGpuCoreException.TestAmdGpuCoreException.test_exception_stop_reason)
PASS: LLDB (/opt/llvm/bin/clang-x86_64) :: test_memory_violation_description (TestAmdGpuCoreException.TestAmdGpuCoreException.test_memory_violation_description)
PASS: LLDB (/opt/llvm/bin/clang-x86_64) :: test_selected_thread_is_memory_violation (TestAmdGpuCoreException.TestAmdGpuCoreException.test_selected_thread_is_memory_violation)
----------------------------------------------------------------------
Ran 4 tests in 25.873s

OK

--

********************

Testing Time: 26.18s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```