### PR TITLE
[lldb] Cache clang offload bundle entries per file

### DIFF
--- a/lldb/source/Plugins/ObjectContainer/Clang-Offload-Bundle/ObjectContainerClangOffloadBundle.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Clang-Offload-Bundle/ObjectContainerClangOffloadBundle.cpp
@@ -10,6 +10,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Host/FileSystem.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ArchSpec.h"
@@ -18,8 +19,7 @@
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Object/OffloadBundle.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Chrono.h"
 #include <mutex>
 
 using namespace lldb;
@@ -81,60 +81,67 @@ bool ObjectContainerClangOffloadBundle::FindBundleEntries(
   if (path.empty())
     return false;
 
-  // A bundle can hold many code objects that each load as a separate module,
-  // so cache the parse per file to avoid rescanning it once per object. Keyed
-  // by path + size + mtime so a changed file re-parses; locked because modules
-  // may load concurrently.
+  // Cache the parse per file so a bundle with many code objects isn't rescanned
+  // once per object. Keyed by path and validated by mtime, so a changed file
+  // re-parses and overwrites. Locked for concurrent module loads.
+  struct CacheValue {
+    llvm::sys::TimePoint<> mod_time;
+    std::vector<Entry> entries;
+  };
   static std::mutex cache_mutex;
-  static llvm::StringMap<std::vector<Entry>> cache;
+  static llvm::StringMap<CacheValue> cache;
 
-  std::string key = path;
-  llvm::sys::fs::file_status status;
-  if (!llvm::sys::fs::status(path, status)) {
-    llvm::raw_string_ostream(key)
-        << ':' << status.getSize() << ':'
-        << llvm::sys::toTimeT(status.getLastModificationTime());
-  }
+  llvm::sys::TimePoint<> mod_time =
+      FileSystem::Instance().GetModificationTime(file);
 
   {
     std::lock_guard<std::mutex> lock(cache_mutex);
-    auto it = cache.find(key);
-    if (it != cache.end()) {
-      entries = it->second;
+    auto it = cache.find(path);
+    if (it != cache.end() && it->second.mod_time == mod_time) {
+      entries = it->second.entries;
       return !entries.empty();
     }
   }
 
-  std::vector<Entry> parsed;
-  auto obj_or_err = llvm::object::ObjectFile::createObjectFile(path);
-  if (obj_or_err) {
+  // Parse the offload bundle (helper keeps this separate from the caching).
+  auto parse = [&path]() -> std::vector<Entry> {
+    std::vector<Entry> result;
+    auto obj_or_err = llvm::object::ObjectFile::createObjectFile(path);
+    if (!obj_or_err) {
+      llvm::consumeError(obj_or_err.takeError());
+      return result;
+    }
+
     llvm::SmallVector<llvm::object::OffloadBundleFatBin> bundles;
     if (auto err = llvm::object::extractOffloadBundleFatBinary(
             *obj_or_err->getBinary(), bundles)) {
       llvm::consumeError(std::move(err));
-    } else {
-      for (auto &bundle : bundles) {
-        for (auto &bundle_entry : bundle.getEntries()) {
-          if (bundle_entry.Size == 0)
-            continue;
-          Entry entry;
-          entry.arch = ParseArchFromBundleEntryID(bundle_entry.ID);
-          entry.offset = bundle_entry.Offset;
-          entry.size = bundle_entry.Size;
-          entry.id = bundle_entry.ID;
-          if (entry.arch.IsValid())
-            parsed.push_back(std::move(entry));
-        }
+      return result;
+    }
+
+    for (auto &bundle : bundles) {
+      for (auto &bundle_entry : bundle.getEntries()) {
+        if (bundle_entry.Size == 0)
+          continue;
+        Entry entry;
+        entry.arch = ParseArchFromBundleEntryID(bundle_entry.ID);
+        entry.offset = bundle_entry.Offset;
+        entry.size = bundle_entry.Size;
+        entry.id = bundle_entry.ID;
+        if (entry.arch.IsValid())
+          result.push_back(std::move(entry));
       }
     }
-  } else {
-    llvm::consumeError(obj_or_err.takeError());
-  }
+    return result;
+  };
 
-  // Cache even an empty result so non-bundle files are not re-parsed.
+  std::vector<Entry> parsed = parse();
+
+  // Store/overwrite this path's entry; cache empty results too so non-bundle
+  // files aren't re-parsed.
   {
     std::lock_guard<std::mutex> lock(cache_mutex);
-    cache[key] = parsed;
+    cache[path] = CacheValue{mod_time, parsed};
   }
 
   entries = std::move(parsed);

--- a/lldb/source/Plugins/ObjectContainer/Clang-Offload-Bundle/ObjectContainerClangOffloadBundle.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Clang-Offload-Bundle/ObjectContainerClangOffloadBundle.cpp
@@ -14,9 +14,13 @@
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/DataBuffer.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Object/OffloadBundle.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+#include <mutex>
 
 using namespace lldb;
 using namespace lldb_private;
@@ -77,36 +81,63 @@ bool ObjectContainerClangOffloadBundle::FindBundleEntries(
   if (path.empty())
     return false;
 
-  auto obj_or_err = llvm::object::ObjectFile::createObjectFile(path);
-  if (!obj_or_err) {
-    llvm::consumeError(obj_or_err.takeError());
-    return false;
+  // A bundle can hold many code objects that each load as a separate module,
+  // so cache the parse per file to avoid rescanning it once per object. Keyed
+  // by path + size + mtime so a changed file re-parses; locked because modules
+  // may load concurrently.
+  static std::mutex cache_mutex;
+  static llvm::StringMap<std::vector<Entry>> cache;
+
+  std::string key = path;
+  llvm::sys::fs::file_status status;
+  if (!llvm::sys::fs::status(path, status)) {
+    llvm::raw_string_ostream(key)
+        << ':' << status.getSize() << ':'
+        << llvm::sys::toTimeT(status.getLastModificationTime());
   }
 
-  llvm::SmallVector<llvm::object::OffloadBundleFatBin> bundles;
-  if (auto err = llvm::object::extractOffloadBundleFatBinary(
-          *obj_or_err->getBinary(), bundles)) {
-    llvm::consumeError(std::move(err));
-    return false;
-  }
-
-  if (bundles.empty())
-    return false;
-
-  for (auto &bundle : bundles) {
-    for (auto &bundle_entry : bundle.getEntries()) {
-      if (bundle_entry.Size == 0)
-        continue;
-      Entry entry;
-      entry.arch = ParseArchFromBundleEntryID(bundle_entry.ID);
-      entry.offset = bundle_entry.Offset;
-      entry.size = bundle_entry.Size;
-      entry.id = bundle_entry.ID;
-      if (entry.arch.IsValid())
-        entries.push_back(std::move(entry));
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    auto it = cache.find(key);
+    if (it != cache.end()) {
+      entries = it->second;
+      return !entries.empty();
     }
   }
 
+  std::vector<Entry> parsed;
+  auto obj_or_err = llvm::object::ObjectFile::createObjectFile(path);
+  if (obj_or_err) {
+    llvm::SmallVector<llvm::object::OffloadBundleFatBin> bundles;
+    if (auto err = llvm::object::extractOffloadBundleFatBinary(
+            *obj_or_err->getBinary(), bundles)) {
+      llvm::consumeError(std::move(err));
+    } else {
+      for (auto &bundle : bundles) {
+        for (auto &bundle_entry : bundle.getEntries()) {
+          if (bundle_entry.Size == 0)
+            continue;
+          Entry entry;
+          entry.arch = ParseArchFromBundleEntryID(bundle_entry.ID);
+          entry.offset = bundle_entry.Offset;
+          entry.size = bundle_entry.Size;
+          entry.id = bundle_entry.ID;
+          if (entry.arch.IsValid())
+            parsed.push_back(std::move(entry));
+        }
+      }
+    }
+  } else {
+    llvm::consumeError(obj_or_err.takeError());
+  }
+
+  // Cache even an empty result so non-bundle files are not re-parsed.
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    cache[key] = parsed;
+  }
+
+  entries = std::move(parsed);
   return !entries.empty();
 }
 


### PR DESCRIPTION
ObjectContainerClangOffloadBundle::FindBundleEntries() re-opened the file and re-scanned its offload bundle on every call. A single fat binary can embed hundreds of device code objects, each loaded as its own module, so the same bundle was parsed once per embedded object.

Cache the parsed entries per file (keyed by `path`, `size` and `mtime`, guarded by a mutex since modules can load concurrently) so the bundle is scanned only once. 