### PR TITLE
[lldb][AMDGPU] Refactor to move breakpoint and memory handling into ProcessAMDGPU

### DIFF
--- a/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
@@ -44,6 +44,44 @@ class BasicAmdGpuTestCase(AmdGpuTestCaseBase):
         gpu_threads = self.run_to_gpu_breakpoint(source, "// GPU BREAKPOINT")
         self.assertNotEqual(None, gpu_threads, "GPU should be stopped at breakpoint")
 
+    def test_gpu_breakpoint_delete(self):
+        """Test that deleting a GPU breakpoint removes the trap opcode."""
+        self.build()
+
+        target = self.createTestTarget()
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertTrue(process.IsValid(), "Process is valid")
+        self.assertTrue(self.gpu_target.IsValid(), "GPU target should be created")
+
+        source = "hello_world.hip"
+        gpu_bkpt_id = self.set_gpu_source_breakpoint(source, "// GPU BREAKPOINT")
+        self.assertTrue(
+            self.gpu_target.BreakpointDelete(gpu_bkpt_id),
+            "GPU breakpoint should be deleted",
+        )
+
+        self.setAsync(True)
+        listener = self.dbg.GetListener()
+
+        self.select_gpu()
+        self.runCmd("c")
+        lldbutil.expect_state_changes(
+            self, listener, self.gpu_process, [lldb.eStateRunning]
+        )
+
+        self.select_cpu()
+        self.runCmd("c")
+        lldbutil.expect_state_changes(
+            self, listener, self.cpu_process, [lldb.eStateRunning]
+        )
+
+        lldbutil.expect_state_changes(
+            self, listener, self.gpu_process, [lldb.eStateExited]
+        )
+        lldbutil.expect_state_changes(
+            self, listener, self.cpu_process, [lldb.eStateExited]
+        )
+
     def test_num_threads(self):
         """Test that we get the expected number of threads."""
         self.build()

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.cpp
@@ -25,10 +25,8 @@
 #include <cinttypes>
 #include <cstdint>
 #include <optional>
-#include <sys/ptrace.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <sys/uio.h>
 #include <thread>
 #include <unistd.h>
 
@@ -230,13 +228,11 @@ Status LLDBServerPluginAMDGPU::AttachAmdDbgApi() {
     std::string error = llvm::toString(architecture_id.takeError());
     return HandleAmdDbgApiAttachError(error.c_str(), AMD_DBGAPI_STATUS_ERROR);
   }
-  m_architecture_id = *architecture_id;
-
   // The process from LLDB’s PoV is the entire portion of logical GPU bound to
   // the CPU host process. It does not represent a real process on the GPU. The
   // The GPU process is fake and shouldn't fail to launch. Let's abort if we see
   // an error.
-  error = CreateGpuProcess();
+  error = CreateGpuProcess(*architecture_id);
   if (error.Fail()) {
     return HandleAmdDbgApiAttachError(error.AsCString(),
                                       AMD_DBGAPI_STATUS_ERROR);
@@ -429,10 +425,12 @@ Status LLDBServerPluginAMDGPU::InstallAmdDbgApiNotifierOnMainLoop() {
   return error;
 }
 
-Status LLDBServerPluginAMDGPU::CreateGpuProcess() {
+Status LLDBServerPluginAMDGPU::CreateGpuProcess(
+    amd_dbgapi_architecture_id_t architecture_id) {
   ProcessManagerAMDGPU *manager =
       (ProcessManagerAMDGPU *)m_process_manager_up.get();
   manager->m_debugger = this;
+  manager->m_architecture_id = architecture_id;
 
   // During initialization, there might be no code objects loaded, so we don't
   // have anything tangible to use as the identifier or file for the GPU
@@ -594,79 +592,6 @@ void LLDBServerPluginAMDGPU::GpuRuntimeDidLoad() {
   }
 
   m_amd_dbg_api_state = AmdDbgApiState::RuntimeLoaded;
-}
-
-bool LLDBServerPluginAMDGPU::SetGPUBreakpoint(uint64_t addr,
-                                              const uint8_t *bp_instruction,
-                                              size_t size) {
-  struct BreakpointInfo {
-    uint64_t addr;
-    std::vector<uint8_t> original_bytes;
-    std::vector<uint8_t> breakpoint_instruction;
-    std::optional<amd_dbgapi_breakpoint_id_t> gpu_breakpoint_id;
-  };
-
-  BreakpointInfo bp;
-  bp.addr = addr;
-  bp.breakpoint_instruction.assign(bp_instruction, bp_instruction + size);
-  bp.original_bytes.resize(size);
-  bp.gpu_breakpoint_id =
-      std::nullopt; // No GPU breakpoint ID for ptrace version
-
-  // TODO: use memory read/write API from native process instead of ptrace
-  // directly.
-  auto pid = GetNativeProcess()->GetID();
-  // Read original bytes word by word
-  std::vector<long> original_words;
-  for (size_t i = 0; i < size; i += sizeof(long)) {
-    long word = ptrace(PTRACE_PEEKDATA, pid, addr + i, nullptr);
-    assert(word != -1 && errno == 0);
-
-    original_words.push_back(word);
-    // Copy bytes from the word into our original_bytes
-    size_t bytes_to_copy = std::min(sizeof(long), size - i);
-    memcpy(&bp.original_bytes[i], &word, bytes_to_copy);
-  }
-
-  // Write breakpoint instruction word by word
-  for (size_t i = 0; i < size; i += sizeof(long)) {
-    long word = original_words[i / sizeof(long)];
-    size_t bytes_to_copy = std::min(sizeof(long), size - i);
-    memcpy(&word, &bp_instruction[i], bytes_to_copy);
-
-    auto ret = ptrace(PTRACE_POKEDATA, pid, addr + i, word);
-    assert(ret != -1 && errno == 0);
-  }
-  return true;
-}
-
-bool LLDBServerPluginAMDGPU::CreateGPUBreakpoint(uint64_t addr) {
-  // Get breakpoint instruction
-  const uint8_t *bp_instruction;
-  amd_dbgapi_status_t status = amd_dbgapi_architecture_get_info(
-      m_architecture_id, AMD_DBGAPI_ARCHITECTURE_INFO_BREAKPOINT_INSTRUCTION,
-      sizeof(bp_instruction), &bp_instruction);
-  if (status != AMD_DBGAPI_STATUS_SUCCESS) {
-    LLDB_LOGF(GetLog(GDBRLog::Plugin),
-              "AMD_DBGAPI_ARCHITECTURE_INFO_BREAKPOINT_INSTRUCTION failed");
-    return false;
-  }
-
-  // Get breakpoint instruction size
-  size_t bp_size;
-  status = amd_dbgapi_architecture_get_info(
-      m_architecture_id,
-      AMD_DBGAPI_ARCHITECTURE_INFO_BREAKPOINT_INSTRUCTION_SIZE, sizeof(bp_size),
-      &bp_size);
-  if (status != AMD_DBGAPI_STATUS_SUCCESS) {
-    LLDB_LOGF(
-        GetLog(GDBRLog::Plugin),
-        "AMD_DBGAPI_ARCHITECTURE_INFO_BREAKPOINT_INSTRUCTION_SIZE failed");
-    return false;
-  }
-
-  // Now call SetGPUBreakpoint with the retrieved instruction and size
-  return SetGPUBreakpoint(addr, bp_instruction, bp_size);
 }
 
 llvm::Expected<GPUPluginBreakpointHitResponse>

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.h
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/LLDBServerPluginAMDGPU.h
@@ -83,7 +83,6 @@ public:
   // Free the memory using the matching callback provided to the debug library.
   static void FreeDbgApiClientMemory(void *mem);
 
-  bool CreateGPUBreakpoint(uint64_t addr);
   llvm::StringRef GetSessionName();
 
   void GpuRuntimeDidLoad();
@@ -99,14 +98,13 @@ public:
   // This is required synchronize setting the GPU internal breakpoint before
   // further actions can be taken.
   bool m_wait_for_gpu_internal_bp_stop = false;
-  amd_dbgapi_architecture_id_t m_architecture_id = AMD_DBGAPI_ARCHITECTURE_NONE;
 
 private:
   Status InitializeAmdDbgApi();
   Status AttachAmdDbgApi();
   Status DetachAmdDbgApi();
   Status InstallAmdDbgApiNotifierOnMainLoop();
-  Status CreateGpuProcess();
+  Status CreateGpuProcess(amd_dbgapi_architecture_id_t architecture_id);
   std::optional<GPUPluginConnectionInfo> CreateConnection();
   GPUActions SetGpuLoaderBreakpointByAddress();
   GPUActions SetConnectionInfo();
@@ -125,8 +123,6 @@ private:
   process_event_queue(amd_dbgapi_event_kind_t until_event_kind,
                       EventBoundaryType boundary_type = ProcessEventInclusive);
   void HandleNotifierDataReady();
-  bool SetGPUBreakpoint(uint64_t addr, const uint8_t *bp_instruction,
-                        size_t size);
   bool ReadyToAttachDebugLibrary();
   bool ReadyToSetGpuLoaderBreakpointByAddress();
   ProcessAMDGPU *GetGPUProcess() const;

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.cpp
@@ -30,6 +30,9 @@
 
 #include <amd-dbgapi/amd-dbgapi.h>
 #include <cinttypes>
+#include <optional>
+#include <string>
+#include <vector>
 
 using namespace lldb;
 using namespace lldb_private;
@@ -37,8 +40,10 @@ using namespace lldb_private::lldb_server;
 using namespace lldb_private::process_gdb_remote;
 
 ProcessAMDGPU::ProcessAMDGPU(lldb::pid_t pid, NativeDelegate &delegate,
-                             LLDBServerPluginAMDGPU *plugin)
-    : NativeProcessProtocol(pid, -1, delegate), m_debugger(plugin) {
+                             LLDBServerPluginAMDGPU *plugin,
+                             amd_dbgapi_architecture_id_t architecture_id)
+    : NativeProcessProtocol(pid, -1, delegate), m_debugger(plugin),
+      m_architecture_id(architecture_id) {
   m_state = eStateStopped;
 }
 
@@ -81,12 +86,18 @@ Status ProcessAMDGPU::Kill() { return Status(); }
 
 Status ProcessAMDGPU::ReadMemory(lldb::addr_t addr, void *buf, size_t size,
                                  size_t &bytes_read) {
-  return Status::FromErrorString("unimplemented");
+  NativeProcessProtocol *native_process = m_debugger->GetNativeProcess();
+  if (!native_process)
+    return Status::FromErrorString("native process is unavailable");
+  return native_process->ReadMemory(addr, buf, size, bytes_read);
 }
 
 Status ProcessAMDGPU::WriteMemory(lldb::addr_t addr, const void *buf,
                                   size_t size, size_t &bytes_written) {
-  return Status::FromErrorString("unimplemented");
+  NativeProcessProtocol *native_process = m_debugger->GetNativeProcess();
+  if (!native_process)
+    return Status::FromErrorString("native process is unavailable");
+  return native_process->WriteMemory(addr, buf, size, bytes_written);
 }
 
 std::vector<AddressSpaceInfo> ProcessAMDGPU::GetAddressSpaces() {
@@ -117,7 +128,7 @@ Status ProcessAMDGPU::ReadMemoryWithSpace(lldb::addr_t addr,
   amd_dbgapi_address_space_id_t address_space_id;
   if (llvm::Error err = RunAmdDbgApiCommand([&] {
         return amd_dbgapi_dwarf_address_space_to_address_space(
-            m_debugger->m_architecture_id, addr_space, &address_space_id);
+            m_architecture_id, addr_space, &address_space_id);
       }))
     return Status::FromError(std::move(err));
 
@@ -213,9 +224,8 @@ const ArchSpec &ProcessAMDGPU::GetArchitecture() const {
   // Query the subtype from the dbgapi.
   uint32_t cpu_subtype = 0;
   amd_dbgapi_status_t status = amd_dbgapi_architecture_get_info(
-      m_debugger->m_architecture_id,
-      AMD_DBGAPI_ARCHITECTURE_INFO_ELF_AMDGPU_MACHINE, sizeof(cpu_subtype),
-      &cpu_subtype);
+      m_architecture_id, AMD_DBGAPI_ARCHITECTURE_INFO_ELF_AMDGPU_MACHINE,
+      sizeof(cpu_subtype), &cpu_subtype);
   if (status != AMD_DBGAPI_STATUS_SUCCESS) {
     LLDB_LOGF(GetLog(GDBRLog::Plugin),
               "amd_dbgapi_architecture_get_info failed: %d", status);
@@ -229,11 +239,40 @@ const ArchSpec &ProcessAMDGPU::GetArchitecture() const {
 // Breakpoint functions
 Status ProcessAMDGPU::SetBreakpoint(lldb::addr_t addr, uint32_t size,
                                     bool hardware) {
-  bool success = m_debugger->CreateGPUBreakpoint(addr);
-  if (!success) {
-    return Status::FromErrorString("CreateGPUBreakpoint failed");
-  }
-  return Status();
+  if (hardware)
+    return Status::FromErrorString("hardware breakpoints are not supported");
+
+  return SetSoftwareBreakpoint(addr, size);
+}
+
+Status ProcessAMDGPU::RemoveBreakpoint(lldb::addr_t addr, bool hardware) {
+  return NativeProcessProtocol::RemoveBreakpoint(addr, hardware);
+}
+
+llvm::Expected<llvm::ArrayRef<uint8_t>>
+ProcessAMDGPU::GetSoftwareBreakpointTrapOpcode(size_t) {
+  if (!m_breakpoint_trap_opcode.empty())
+    return llvm::ArrayRef<uint8_t>(m_breakpoint_trap_opcode);
+
+  const uint8_t *bp_instruction = nullptr;
+  amd_dbgapi_status_t status = amd_dbgapi_architecture_get_info(
+      m_architecture_id, AMD_DBGAPI_ARCHITECTURE_INFO_BREAKPOINT_INSTRUCTION,
+      sizeof(bp_instruction), &bp_instruction);
+  if (status != AMD_DBGAPI_STATUS_SUCCESS)
+    return llvm::createStringError(
+        "AMD_DBGAPI_ARCHITECTURE_INFO_BREAKPOINT_INSTRUCTION failed");
+
+  size_t bp_size = 0;
+  status = amd_dbgapi_architecture_get_info(
+      m_architecture_id,
+      AMD_DBGAPI_ARCHITECTURE_INFO_BREAKPOINT_INSTRUCTION_SIZE, sizeof(bp_size),
+      &bp_size);
+  if (status != AMD_DBGAPI_STATUS_SUCCESS)
+    return llvm::createStringError(
+        "AMD_DBGAPI_ARCHITECTURE_INFO_BREAKPOINT_INSTRUCTION_SIZE failed");
+
+  m_breakpoint_trap_opcode.assign(bp_instruction, bp_instruction + bp_size);
+  return llvm::ArrayRef<uint8_t>(m_breakpoint_trap_opcode);
 }
 
 llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
@@ -320,8 +359,8 @@ ProcessManagerAMDGPU::Launch(
     ProcessLaunchInfo &launch_info,
     NativeProcessProtocol::NativeDelegate &native_delegate) {
   lldb::pid_t pid = launch_info.GetProcessID();
-  auto proc_up =
-      std::make_unique<ProcessAMDGPU>(pid, native_delegate, m_debugger);
+  auto proc_up = std::make_unique<ProcessAMDGPU>(pid, native_delegate,
+                                                 m_debugger, m_architecture_id);
   proc_up->SetLaunchInfo(launch_info);
   return proc_up;
 }
@@ -358,10 +397,18 @@ bool ProcessAMDGPU::handleWaveStop(amd_dbgapi_event_id_t eventId) {
                 status);
       exit(-1);
     }
-    pc -= 4;
+    llvm::Expected<llvm::ArrayRef<uint8_t>> breakpoint_opcode =
+        GetSoftwareBreakpointTrapOpcode(/*size_hint=*/0);
+    if (!breakpoint_opcode) {
+      std::string error = llvm::toString(breakpoint_opcode.takeError());
+      LLDB_LOGF(GetLog(GDBRLog::Plugin),
+                "GetSoftwareBreakpointTrapOpcode failed: %s", error.c_str());
+      exit(-1);
+    }
+    pc -= breakpoint_opcode->size();
     amd_dbgapi_register_id_t pc_register_id;
     status = amd_dbgapi_architecture_get_info(
-        m_debugger->m_architecture_id, AMD_DBGAPI_ARCHITECTURE_INFO_PC_REGISTER,
+        m_architecture_id, AMD_DBGAPI_ARCHITECTURE_INFO_PC_REGISTER,
         sizeof(pc_register_id), &pc_register_id);
     if (status != AMD_DBGAPI_STATUS_SUCCESS) {
       LLDB_LOGF(GetLog(GDBRLog::Plugin),

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.h
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.h
@@ -16,6 +16,8 @@
 #include "lldb/Host/common/NativeProcessProtocol.h"
 #include "lldb/Utility/ProcessInfo.h"
 #include <amd-dbgapi/amd-dbgapi.h>
+#include <optional>
+#include <vector>
 
 namespace lldb_private {
 namespace lldb_server {
@@ -30,8 +32,9 @@ class ProcessAMDGPU : public NativeProcessProtocol {
   ProcessInstanceInfo m_process_info;
 
 public:
-  ProcessAMDGPU(lldb::pid_t pid, NativeDelegate &delegate, 
-                LLDBServerPluginAMDGPU *plugin);
+  ProcessAMDGPU(lldb::pid_t pid, NativeDelegate &delegate,
+                LLDBServerPluginAMDGPU *plugin,
+                amd_dbgapi_architecture_id_t architecture_id);
 
   Status Resume(const ResumeActionList &resume_actions) override;
 
@@ -78,6 +81,7 @@ public:
   // Breakpoint functions
   Status SetBreakpoint(lldb::addr_t addr, uint32_t size,
                        bool hardware) override;
+  Status RemoveBreakpoint(lldb::addr_t addr, bool hardware = false) override;
 
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
   GetAuxvData() const override;
@@ -112,7 +116,11 @@ public:
     return amd_dbgapi_process_id_t{m_pid};
   }
 
-  LLDBServerPluginAMDGPU* m_debugger = nullptr;
+  amd_dbgapi_architecture_id_t GetDbgApiArchitectureID() const {
+    return m_architecture_id;
+  }
+
+  LLDBServerPluginAMDGPU *m_debugger = nullptr;
   GpuModuleManager m_gpu_module_manager;
 
   enum class State {
@@ -132,7 +140,13 @@ public:
       std::function<lldb_private::IterationAction(ThreadAMDGPU &)> const
           &callback);
 
+protected:
+  llvm::Expected<llvm::ArrayRef<uint8_t>>
+  GetSoftwareBreakpointTrapOpcode(size_t size_hint) override;
+
 private:
+  amd_dbgapi_architecture_id_t m_architecture_id = AMD_DBGAPI_ARCHITECTURE_NONE;
+  std::vector<uint8_t> m_breakpoint_trap_opcode;
   WaveIdMap<std::shared_ptr<WaveAMDGPU>> m_waves;
   WaveIdList UpdateWavesAndReturnNew();
   llvm::Expected<DbgApiClientMemoryPtr<amd_dbgapi_wave_id_t>>
@@ -162,7 +176,8 @@ public:
   Attach(lldb::pid_t pid,
          NativeProcessProtocol::NativeDelegate &native_delegate) override;
 
-    LLDBServerPluginAMDGPU* m_debugger = nullptr;
+  LLDBServerPluginAMDGPU *m_debugger = nullptr;
+  amd_dbgapi_architecture_id_t m_architecture_id = AMD_DBGAPI_ARCHITECTURE_NONE;
 };
 
 } // namespace lldb_server

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/RegisterContextAmdGpu.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/RegisterContextAmdGpu.cpp
@@ -8,7 +8,6 @@
 
 #include "RegisterContextAmdGpu.h"
 
-#include "LLDBServerPluginAMDGPU.h"
 #include "ProcessAMDGPU.h"
 #include "ThreadAMDGPU.h"
 #include "lldb/Utility/DataBufferHeap.h"
@@ -23,7 +22,7 @@ RegisterContextAmdGpu::RegisterContextAmdGpu(
     : NativeRegisterContext(native_thread) {
   ThreadAMDGPU *thread = static_cast<ThreadAMDGPU *>(&native_thread);
   amd_dbgapi_architecture_id_t architecture_id =
-      thread->GetProcess().m_debugger->m_architecture_id;
+      thread->GetProcess().GetDbgApiArchitectureID();
 
   m_impl = std::make_unique<RegisterContextAmdGpuImpl>(
       architecture_id, /*is_shawdow_thread=*/thread->IsShadowThread());


### PR DESCRIPTION
This PR refactors the old hacky implementation to move all the breakpoint/memory related operations from LLDBServerPluginAMDGPU into ProcessAMDGPU. 
The other change is, instead of manually setting breakpoint, we are relying on lldb-server's existing software breakpoint mechanism by overriding `GetSoftwareBreakpointTrapOpcode`.

All existing tests are still passing.