### PR TITLE
[lldb][AMDGPU] Add basic resume/stepping support

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/gpu/amdgpu_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/gpu/amdgpu_testcase.py
@@ -90,6 +90,65 @@ class AmdGpuTestCaseBase(GpuTestCaseBase):
             self.gpu_process, gpu_bkpt_id
         )
 
+    def stop_cpu_if_running(self, listener: lldb.SBListener):
+        if self.cpu_process.GetState() != lldb.eStateRunning:
+            return
+
+        error = self.cpu_process.Stop()
+        self.assertSuccess(error, "interrupt CPU process")
+        lldbutil.expect_state_changes(
+            self, listener, self.cpu_process, [lldb.eStateStopped]
+        )
+
+    def continue_gpu_to_breakpoint(self, gpu_bkpt_id: int) -> List[lldb.SBThread]:
+        """Continue the GPU process until it hits the requested breakpoint."""
+        self.setAsync(True)
+        listener = self.dbg.GetListener()
+        self.stop_cpu_if_running(listener)
+
+        self.dbg.SetSelectedTarget(self.gpu_target)
+        error = self.gpu_process.Continue()
+        self.assertSuccess(error, "continue GPU process")
+        lldbutil.expect_state_changes(
+            self,
+            listener,
+            self.gpu_process,
+            [lldb.eStateRunning, lldb.eStateStopped],
+        )
+        return lldbutil.get_threads_stopped_at_breakpoint_id(
+            self.gpu_process, gpu_bkpt_id
+        )
+
+    def step_over_gpu_thread(self, thread: lldb.SBThread, expected_line: int):
+        """Step over one GPU thread and verify that the step plan completes."""
+        self.setAsync(True)
+        listener = self.dbg.GetListener()
+
+        self.stop_cpu_if_running(listener)
+
+        self.dbg.SetSelectedTarget(self.gpu_target)
+        self.assertTrue(self.gpu_process.SetSelectedThread(thread), "select GPU thread")
+        thread_id = thread.GetThreadID()
+        before_pc = thread.GetFrameAtIndex(0).GetPC()
+
+        error = lldb.SBError()
+        thread.StepOver(lldb.eOnlyDuringStepping, error)
+        self.assertSuccess(error, "step over GPU thread")
+        lldbutil.expect_state_changes(
+            self,
+            listener,
+            self.gpu_process,
+            [lldb.eStateRunning, lldb.eStateStopped],
+        )
+
+        selected_thread = self.gpu_process.GetSelectedThread()
+        self.assertEqual(thread_id, selected_thread.GetThreadID())
+        self.assertEqual(lldb.eStopReasonPlanComplete, selected_thread.GetStopReason())
+        self.assertNotEqual(before_pc, selected_thread.GetFrameAtIndex(0).GetPC())
+        self.assertEqual(
+            expected_line, selected_thread.GetFrameAtIndex(0).GetLineEntry().GetLine()
+        )
+
     def continue_to_gpu_source_breakpoint(
         self, source: str, gpu_bkpt_pattern: str
     ) -> List[lldb.SBThread]:

--- a/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/basic/TestBasicAmdGpuPlugin.py
@@ -44,6 +44,40 @@ class BasicAmdGpuTestCase(AmdGpuTestCaseBase):
         gpu_threads = self.run_to_gpu_breakpoint(source, "// GPU BREAKPOINT")
         self.assertNotEqual(None, gpu_threads, "GPU should be stopped at breakpoint")
 
+    def test_gpu_basic_step_over(self):
+        """Test that a GPU thread can step over a source line."""
+        self.build()
+
+        source = "hello_world.hip"
+        gpu_threads = self.run_to_gpu_breakpoint(source, "// GPU BREAKPOINT")
+        self.assertNotEqual(None, gpu_threads, "GPU should be stopped at breakpoint")
+        self.step_over_gpu_thread(
+            gpu_threads[0], line_number(source, "// GPU STEP OVER")
+        )
+
+    def test_gpu_resume_to_next_breakpoint(self):
+        """Test that resuming GPU threads can hit a later breakpoint."""
+        self.build()
+
+        source = "hello_world.hip"
+        target = lldbutil.run_to_breakpoint_make_target(self)
+        launch_info = target.GetLaunchInfo()
+        launch_info.SetWorkingDirectory(self.get_process_working_directory())
+        error = lldb.SBError()
+        process = target.Launch(launch_info, error)
+        self.assertTrue(process, "Could not create a valid process")
+        self.assertFalse(error.Fail(), "Process launch failed: %s" % error.GetCString())
+        self.assertTrue(self.gpu_target.IsValid(), "GPU target should be created")
+
+        first_bkpt_id = self.set_gpu_source_breakpoint(source, "// GPU BREAKPOINT")
+        next_bkpt_id = self.set_gpu_source_breakpoint(source, "// GPU BREAKPOINT AFTER")
+
+        gpu_threads = self.continue_to_gpu_breakpoint(first_bkpt_id)
+        self.assertNotEqual(None, gpu_threads, "GPU should be stopped at breakpoint")
+
+        gpu_threads = self.continue_gpu_to_breakpoint(next_bkpt_id)
+        self.assertNotEqual(None, gpu_threads, "GPU should hit next breakpoint")
+
     def test_gpu_breakpoint_delete(self):
         """Test that deleting a GPU breakpoint removes the trap opcode."""
         self.build()

--- a/lldb/test/API/gpu/amd/basic/hello_world.hip
+++ b/lldb/test/API/gpu/amd/basic/hello_world.hip
@@ -72,7 +72,8 @@ __global__ void helloworld_kernel(char *str, size_t size) {
   }
 
   if (idx < size) { // GPU BREAKPOINT
-    str[idx] = c;
+    str[idx] = c; // GPU STEP OVER
+    c = str[idx]; // GPU BREAKPOINT AFTER
   }
 }
 

--- a/lldb/test/API/gpu/amd/multi-wave/TestMultiWaveAmdGpuPlugin.py
+++ b/lldb/test/API/gpu/amd/multi-wave/TestMultiWaveAmdGpuPlugin.py
@@ -36,3 +36,13 @@ class BasicAmdGpuTestCase(AmdGpuTestCaseBase):
         # stopped at the breakpoint. With wave size of 64, this means we should
         # have at least 56 threads (120 = 64 + 56) hitting the breakpoint.
         self.assertGreaterEqual(len(gpu_threads_at_breakpoint), 56)
+
+    def test_step_over_from_multi_wave_breakpoint(self):
+        """Test stepping when multiple GPU waves are stopped at a breakpoint."""
+        self.build()
+
+        source = "multi-wave.hip"
+        gpu_threads_at_breakpoint = self.run_to_breakpoint()
+        self.step_over_gpu_thread(
+            gpu_threads_at_breakpoint[0], line_number(source, "// GPU STEP OVER")
+        )

--- a/lldb/test/API/gpu/amd/multi-wave/multi-wave.hip
+++ b/lldb/test/API/gpu/amd/multi-wave/multi-wave.hip
@@ -86,7 +86,7 @@ __global__ void multi_wave_kernel(unsigned *buf, bool sync_threads) {
   }
   unsigned int thread_idx = get_global_idx();
   buf[thread_idx] = thread_idx; // GPU BREAKPOINT
-}
+} // GPU STEP OVER
 
 int main() {
   const dim3 blocks(2, 2, 2);  // 3D grid specifying number of blocks to launch

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.cpp
@@ -32,6 +32,7 @@
 #include <cinttypes>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 using namespace lldb;
@@ -48,9 +49,118 @@ ProcessAMDGPU::ProcessAMDGPU(lldb::pid_t pid, NativeDelegate &delegate,
 }
 
 Status ProcessAMDGPU::Resume(const ResumeActionList &resume_actions) {
-  SetState(StateType::eStateRunning, true);
-  ThreadAMDGPU *thread = (ThreadAMDGPU *)GetCurrentThread();
-  thread->GetRegisterContext().InvalidateAllRegisters();
+  Log *log = GetLog(GDBRLog::Plugin);
+  LLDB_LOG(log, "pid {0}", GetID());
+
+  NotifyTracersProcessWillResume();
+
+  struct WaveResumeAction {
+    lldb::StateType resume_state = eStateInvalid;
+    std::vector<ThreadAMDGPU *> lanes;
+  };
+
+  std::unordered_map<WaveAMDGPU *, WaveResumeAction> wave_actions;
+  wave_actions.reserve(m_threads.size());
+  bool had_resume_action = false;
+
+  // LLDB models every GPU lane as a thread because that is the granularity the
+  // user selects, inspects, and steps in the UI. The dbgapi control operation
+  // is coarser: a resume request applies to the whole wave. Build one physical
+  // resume request per wave from the logical lane requests before calling into
+  // dbgapi.
+  for (const auto &thread : m_threads) {
+    assert(thread && "thread list should not contain NULL threads");
+    ThreadAMDGPU *gpu_thread = static_cast<ThreadAMDGPU *>(thread.get());
+
+    const ResumeAction *const action =
+        resume_actions.GetActionForThread(thread->GetID(), true);
+
+    // The shadow thread is LLDB's placeholder before real GPU lanes are
+    // materialized. It has no backing wave to resume, but a resume action for
+    // it still means the GPU process should transition to running below.
+    if (gpu_thread->IsShadowThread()) {
+      had_resume_action = action && (action->state == eStateRunning ||
+                                     action->state == eStateStepping);
+      continue;
+    }
+
+    WaveResumeAction &wave_action = wave_actions[gpu_thread->GetWave()];
+    wave_action.lanes.push_back(gpu_thread);
+
+    if (action == nullptr) {
+      LLDB_LOG(log, "no action specified for pid {0} tid {1}", GetID(),
+               thread->GetID());
+      continue;
+    }
+
+    LLDB_LOG(log, "processing resume action state {0} for pid {1} tid {2}",
+             action->state, GetID(), thread->GetID());
+
+    switch (action->state) {
+    case eStateStepping:
+    case eStateRunning: {
+      had_resume_action = true;
+
+      // Several lane threads can map to the same wave. If LLDB asks to step one
+      // lane while continuing another lane in that wave, the physical operation
+      // must be single-step: issuing a normal resume would overrun the user's
+      // selected step.
+      if (wave_action.resume_state == eStateInvalid) {
+        wave_action.resume_state = action->state;
+      } else if (wave_action.resume_state != action->state) {
+        LLDB_LOG(log,
+                 "coalescing conflicting resume actions for wave {0}: "
+                 "existing state {1}, new state {2}",
+                 gpu_thread->GetWaveID().handle,
+                 StateAsCString(wave_action.resume_state),
+                 StateAsCString(action->state));
+
+        if (action->state == eStateStepping)
+          wave_action.resume_state = eStateStepping;
+      }
+      break;
+    }
+
+    case eStateSuspended:
+    case eStateStopped:
+      // These lane states do not request execution. Other lanes in the same
+      // wave may still cause the wave to resume.
+      break;
+
+    default:
+      return Status::FromErrorStringWithFormat(
+          "NativeProcessLinux::%s (): unexpected state %s specified "
+          "for pid %" PRIu64 ", tid %" PRIu64,
+          __FUNCTION__, StateAsCString(action->state), GetID(),
+          thread->GetID());
+    }
+  }
+
+  // Apply the coalesced actions to each physical wave once. Register values for
+  // all lanes in a resumed wave are invalidated because any lane-visible state
+  // may have changed after the wave executes.
+  for (auto &item : wave_actions) {
+    WaveAMDGPU *wave = item.first;
+    WaveResumeAction &wave_action = item.second;
+    if (wave_action.resume_state != eStateStepping &&
+        wave_action.resume_state != eStateRunning)
+      continue;
+
+    const bool single_step = wave_action.resume_state == eStateStepping;
+    Status resume_result = wave->Resume(single_step);
+    if (resume_result.Fail())
+      return Status::FromErrorStringWithFormat(
+          "NativeProcessLinux::%s: failed to resume wave "
+          "for pid %" PRIu64 ", tid %" PRIu64 ", error = %s",
+          __FUNCTION__, GetID(), wave->GetWaveID().handle,
+          resume_result.AsCString());
+
+    for (ThreadAMDGPU *lane : wave_action.lanes)
+      lane->GetRegisterContext().InvalidateAllRegisters();
+  }
+
+  if (had_resume_action)
+    SetState(StateType::eStateRunning, true);
   return Status();
 }
 
@@ -388,6 +498,7 @@ bool ProcessAMDGPU::handleWaveStop(amd_dbgapi_event_id_t eventId) {
               status);
     return false;
   }
+
   if ((stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT) != 0) {
     uint64_t pc;
     status = amd_dbgapi_wave_get_info(wave_id, AMD_DBGAPI_WAVE_INFO_PC,
@@ -725,9 +836,10 @@ WaveIdList ProcessAMDGPU::UpdateWavesAndReturnNew() {
       m_waves.at(wave_id)->SetDbgApiInfo(*wave_info);
     } else {
       // We failed to get wave info for this wave.
-      LLDB_LOG_ERROR(log, wave_info.takeError(),
-                     "Failed to get wave info for wave {1}. {0}. Marking wave as dead.",
-                     wave_id.handle);
+      LLDB_LOG_ERROR(
+          log, wave_info.takeError(),
+          "Failed to get wave info for wave {1}. {0}. Marking wave as dead.",
+          wave_id.handle);
     }
   }
 

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.h
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/ProcessAMDGPU.h
@@ -97,7 +97,7 @@ public:
   // Custom accessors
   void SetLaunchInfo(ProcessLaunchInfo &launch_info);
 
-  std::optional<GPUDynamicLoaderResponse> 
+  std::optional<GPUDynamicLoaderResponse>
   GetGPUDynamicLoaderLibraryInfos(const GPUDynamicLoaderArgs &args) override;
 
   /// Called when the native process exits to exit the GPU process

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/WaveAMDGPU.cpp
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/WaveAMDGPU.cpp
@@ -134,3 +134,17 @@ void WaveAMDGPU::UpdateStopReasonFromWaveInfo() {
   assert(reason != lldb::StopReason::eStopReasonInvalid);
   SetStopReason(reason, description);
 }
+
+Status WaveAMDGPU::Resume(bool single_step) {
+  // TODO: Handle forwarding or suppressing pending GPU exceptions on resume.
+  amd_dbgapi_exceptions_t exception = AMD_DBGAPI_EXCEPTION_NONE;
+  llvm::Error err = RunAmdDbgApiCommand([&] {
+    return amd_dbgapi_wave_resume(m_wave_id,
+                                  single_step
+                                      ? AMD_DBGAPI_RESUME_MODE_SINGLE_STEP
+                                      : AMD_DBGAPI_RESUME_MODE_NORMAL,
+                                  exception);
+  });
+  Status status = Status::FromError(std::move(err));
+  return status;
+}

--- a/lldb/tools/lldb-server/Plugins/AMDGPU/WaveAMDGPU.h
+++ b/lldb/tools/lldb-server/Plugins/AMDGPU/WaveAMDGPU.h
@@ -75,9 +75,11 @@ public:
     m_stop_info.signo = signo;
   }
 
-private:
+  Status Resume(bool single_step);
+
   void UpdateStopReasonFromWaveInfo();
 
+private:
   amd_dbgapi_wave_id_t m_wave_id;
   DbgApiWaveInfo m_wave_info;
   ThreadStopInfo m_stop_info;


### PR DESCRIPTION
This PR adds basic execution control (resume/stepping) by leveraging existing thread plan.

The tricky thing is, RocLLDB exposes each lane as an LLDB thread, but dbgapi resumes execution at wave granularity. This meant a logical lane resume could not be applied directly when multiple lanes in the same wave had different resume actions.

This PR coalesces lane resume requests into wave-level actions, resumes each affected wave once, and invalidates the registers for lanes whose wave was resumed.

This is essentially wave-centric physical stepping without caring about source level logic. 
There are other issues we need to address in future PRs, including lane-centric divergent stepping, synchronize CPU and GPU execution, terminated kernel threads, stop reason update, lanes sharing the same wave update etc...

Test plan:

- Added AMDGPU API coverage for GPU step-over and resume-to-next-breakpoint.
- Ran: ninja lldb lldb-server lldb-dap
- Ran: ./bin/llvm-lit -av ./llvm-project/lldb/test/API/gpu/amd/