### PR TITLE
[lldb][amdgpu-core] Name file-backed GPU code objects from their NT_FILE path

### DIFF
--- a/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
+++ b/lldb/source/Plugins/Process/amdgpu-core/ProcessAmdGpuCore.cpp
@@ -12,9 +12,11 @@
 
 #include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
 #include "Plugins/ObjectFile/Placeholder/ObjectFilePlaceholder.h"
+#include "Plugins/Process/elf-core/ProcessElfCore.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Target/MemoryRegionInfo.h"
 #include "lldb/Utility/AmdDbgApiUtils.h"
 #include "lldb/Utility/AmdGpuAddressSpaces.h"
 #include "lldb/Utility/AmdGpuCoreUtils.h"
@@ -593,9 +595,28 @@ llvm::Error ProcessAmdGpuCore::LoadModules() {
       }
     }
 
+    // Name a memory:// code object from its NT_FILE backing file (e.g. an
+    // AOTInductor .hsaco) instead of the synthetic "amd_memory_kernel[...]" --
+    // even if the file is absent here, so the placeholder keeps a real name.
+    FileSpec module_file(lib_info->pathname);
+    if (lib_info->native_memory_address.has_value()) {
+      if (std::shared_ptr<ProcessElfCore> cpu_core = GetCpuProcess()) {
+        MemoryRegionInfo region_info;
+        if (cpu_core
+                ->GetMemoryRegionInfo(lib_info->native_memory_address.value(),
+                                      region_info)
+                .Success() &&
+            region_info.GetName()) {
+          module_file = FileSpec(region_info.GetName().GetStringRef());
+          LLDB_LOG(log, "Named \"{0}\" from backing file: {1}",
+                   lib_info->pathname, module_file.GetPath());
+        }
+      }
+    }
+
     // Create a module specification from the info we got.
     UUID uuid;
-    ModuleSpec module_spec(FileSpec(lib_info->pathname), uuid, data_sp);
+    ModuleSpec module_spec(module_file, uuid, data_sp);
 
     // Set file offset and size if available
     if (lib_info->file_offset.has_value())

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -579,6 +579,13 @@ size_t ProcessElfCore::ReadMemory(lldb::addr_t addr, void *buf, size_t size,
 Status ProcessElfCore::DoGetMemoryRegionInfo(lldb::addr_t load_addr,
                                              MemoryRegionInfo &region_info) {
   region_info.Clear();
+
+  // Report the backing file (from the NT_FILE note) like a live process --
+  // works even for file-backed bytes not dumped in the core (no PT_LOAD)
+  if (std::optional<NT_FILE_Entry> file_entry =
+          GetNTFileEntryContainingAddress(load_addr))
+    region_info.SetName(file_entry->path.c_str());
+
   const VMRangeToPermissions::Entry *permission_entry =
       m_core_range_infos.FindEntryThatContainsOrFollows(load_addr);
   if (permission_entry) {

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -1285,6 +1285,21 @@ class LinuxCoreTestCase(TestBase):
         self.assertEqual(exe_module.GetFileSpec().fullpath, "/path/nt_file_foo")
         self.dbg.DeleteTarget(target)
 
+    def test_memory_region_name_from_nt_file(self):
+        # GetMemoryRegionInfo reports the mapped-file name from the NT_FILE note,
+        # even for file-backed bytes not dumped as a PT_LOAD. 0x55BB04288000 is
+        # the NT_FILE mapping for '/path/nt_file_foo' in this core.
+        yaml_path = self.getSourcePath("elf-NT_FILE-NT_PRPSINFO-AT_EXECFN.yaml")
+        core_path = self.getBuildArtifact("elf-NT_FILE-region-name.core")
+        self.yaml2obj(yaml_path, core_path)
+        target = self.dbg.CreateTarget(None)
+        process = target.LoadCore(core_path)
+        region = lldb.SBMemoryRegionInfo()
+        self.assertTrue(
+            process.GetMemoryRegionInfo(0x55BB04288000, region).Success())
+        self.assertEqual(region.GetName(), "/path/nt_file_foo")
+        self.dbg.DeleteTarget(target)
+
     def test_exe_name_extraction_at_execfn(self):
         # This core file has:
         # - AT_EXECFN that points to "/path/execfn_foo"


### PR DESCRIPTION
When a `memory://` GPU code object's bytes aren't dumped in a lightweight core (e.g. an AOTInductor `.hsaco`), `ProcessAmdGpuCore::LoadModules` named it with a synthetic `amd_memory_kernel[start,end)` placeholder. This resolves the object's on-disk backing file from the CPU core's memory map (the `NT_FILE` note) and uses it as the module name, so backtraces and `image list` show the real `.hsaco` path — and when the file is present, symbols load from it. Objects with no backing file (anonymous memory) keep the synthetic name.

Name and content are decoupled: even when the file isn't on this host, the module keeps the real name as a placeholder a symbol server can re-hydrate later.

## Changes

- **elf-core**: `ProcessElfCore::DoGetMemoryRegionInfo` reports the region's mapped-file name from the `NT_FILE` note, even for addresses with no `PT_LOAD`.
- **amdgpu-core**: `LoadModules` names the code object from that region info.

## Testing

- `TestLinuxCore.py::test_memory_region_name_from_nt_file` (GPU-free): asserts `GetMemoryRegionInfo` reports the `NT_FILE` path for an address with no `PT_LOAD`.
- Validated on a real IPNext AMD (gfx942/MI300X) core: with the `.hsaco` present the AOTInductor kernels symbolize from disk; with them absent, backtraces still show the real `.hsaco` path as placeholders instead of `amd_memory_kernel[…]`.



after

```
(lldb) bt
* thread #1, name = 'AMD GPU Thread', stop reason = Address error (address out of range)
  * frame #0: 0x00007f6a33eb9f94 ckq4hskzrtwkbxruge7ofytm2zmahqgcizkszojgcp3eepdubxc2.hsaco
```


before

```
(lldb) bt
* thread #1, name = 'AMD GPU Thread', stop reason = Address error (address out of range)
  * frame #0: 0x00007f6a33eb9f94 amd_memory_kernel[0x7f6b1fd08000, 0x7f6b1fd0a160)
```

after with symbol files locally
```
(lldb) bt
* thread #1, name = 'AMD GPU Thread', stop reason = Address error (address out of range)
  * frame #0: 0x00007f6a33eb9f94 ckq4hskzrtwkbxruge7ofytm2zmahqgcizkszojgcp3eepdubxc2.hsaco`triton_poi_fused__to_copy_clone_mul_permute_unsqueeze_view_270 at csdb37e2jh2nxs4a2zyq3stu7d3r4t52oftqw25tffp7nz7olflo.py:29:75
```
