### PR TITLE
[lldb][elf-core] Report NT_FILE mapped-file name from GetMemoryRegionInfo

### DIFF
--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -579,6 +579,13 @@ size_t ProcessElfCore::ReadMemory(lldb::addr_t addr, void *buf, size_t size,
 Status ProcessElfCore::DoGetMemoryRegionInfo(lldb::addr_t load_addr,
                                              MemoryRegionInfo &region_info) {
   region_info.Clear();
+
+  // Report the backing file (from the NT_FILE note) like a live process --
+  // works even for file-backed bytes not dumped in the core (no PT_LOAD)
+  if (std::optional<NT_FILE_Entry> file_entry =
+          GetNTFileEntryContainingAddress(load_addr))
+    region_info.SetName(file_entry->path.c_str());
+
   const VMRangeToPermissions::Entry *permission_entry =
       m_core_range_infos.FindEntryThatContainsOrFollows(load_addr);
   if (permission_entry) {

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -1285,6 +1285,21 @@ class LinuxCoreTestCase(TestBase):
         self.assertEqual(exe_module.GetFileSpec().fullpath, "/path/nt_file_foo")
         self.dbg.DeleteTarget(target)
 
+    def test_memory_region_name_from_nt_file(self):
+        # GetMemoryRegionInfo reports the mapped-file name from the NT_FILE note,
+        # even for file-backed bytes not dumped as a PT_LOAD. 0x55BB04288000 is
+        # the NT_FILE mapping for '/path/nt_file_foo' in this core.
+        yaml_path = self.getSourcePath("elf-NT_FILE-NT_PRPSINFO-AT_EXECFN.yaml")
+        core_path = self.getBuildArtifact("elf-NT_FILE-region-name.core")
+        self.yaml2obj(yaml_path, core_path)
+        target = self.dbg.CreateTarget(None)
+        process = target.LoadCore(core_path)
+        region = lldb.SBMemoryRegionInfo()
+        self.assertTrue(
+            process.GetMemoryRegionInfo(0x55BB04288000, region).Success())
+        self.assertEqual(region.GetName(), "/path/nt_file_foo")
+        self.dbg.DeleteTarget(target)
+
     def test_exe_name_extraction_at_execfn(self):
         # This core file has:
         # - AT_EXECFN that points to "/path/execfn_foo"


### PR DESCRIPTION
`ProcessElfCore::DoGetMemoryRegionInfo` now reports the region's mapped-file name from the `NT_FILE` note, even for addresses that have no `PT_LOAD` (the file-backed-but-not-dumped case). This matches how a live process reports its mapped files, and lets callers recover the on-disk file backing an address whose bytes weren't dumped into the core.

## Testing

- `TestLinuxCore.py::test_memory_region_name_from_nt_file`: builds a core with `yaml2obj` whose `NT_FILE` note maps a path at an address with no `PT_LOAD`, and asserts `GetMemoryRegionInfo` reports that path.
