### PR TITLE
[LLDB][NVGPU] Fix unit test compilation failures

### DIFF
--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -292,6 +292,7 @@ static llvm::Expected<Value> Evaluate(llvm::ArrayRef<uint8_t> expr,
 
   return DWARFExpression::Evaluate(exe_ctx, reg_ctx, module_sp, extractor, unit,
                                    lldb::eRegisterKindLLDB,
+                                   /*addr_space=*/0,
                                    /*initial_value_ptr=*/nullptr,
                                    /*object_address_ptr=*/nullptr);
 }
@@ -776,6 +777,7 @@ DWARF:
     return DWARFExpression::Evaluate(&exe_ctx, /*reg_ctx*/ nullptr,
                                      /*module_sp*/ {}, extractor, dwarf_cu,
                                      lldb::eRegisterKindLLDB,
+                                     /*addr_space=*/0,
                                      /*initial_value_ptr*/ nullptr,
                                      /*object_address_ptr*/ nullptr);
   };

--- a/lldb/unittests/Symbol/LineTableTest.cpp
+++ b/lldb/unittests/Symbol/LineTableTest.cpp
@@ -104,7 +104,7 @@ private:
   TypeSP MakeType(user_id_t, ConstString, std::optional<uint64_t>,
                   SymbolContextScope *, user_id_t, Type::EncodingDataType,
                   const Declaration &, const CompilerType &, Type::ResolveState,
-                  uint32_t) override {
+                  std::optional<lldb::addr_space_t>, uint32_t) override {
     return nullptr;
   }
   TypeSP CopyType(const TypeSP &) override { return nullptr; }

--- a/lldb/unittests/Symbol/TestDWARFCallFrameInfo.cpp
+++ b/lldb/unittests/Symbol/TestDWARFCallFrameInfo.cpp
@@ -509,10 +509,6 @@ Symbols:
 
 // Test valid CIE markers in eh_frame format
 TEST_F(DWARFCallFrameInfoTest, ValidCIEMarkers_eh_frame) {
-TEST_F(DWARFCallFrameInfoTest, AugmentationString) {
-  // This test verifies that we can parse the larger augmentation string
-  // that is used by the AMDGPU backend. The object file is a stripped down
-  // version that only contains the CIE entry in the .debug_frame section.
   auto ExpectedFile = TestFile::fromYaml(R"(
 --- !ELF
 FileHeader:
@@ -567,6 +563,62 @@ Symbols:
   EXPECT_GE(plan_up->GetRowCount(), 1);
 }
 
+TEST_F(DWARFCallFrameInfoTest, AugmentationString) {
+  // This test verifies that we can parse the larger augmentation string
+  // that is used by the AMDGPU backend. The object file is a stripped down
+  // version that only contains the CIE entry in the .debug_frame section.
+  auto ExpectedFile = TestFile::fromYaml(R"(
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_AMDGPU
+  Flags:           [ EF_AMDGPU_MACH_AMDGCN_GFX942 ]
+Sections:
+  - Name:            .debug_frame
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x0000000000000008
+    Content:         20000000FFFFFFFF045B6C6C766D3A76302E305D00080004041000000000000000000000
+#00000000 00000020 ffffffff CIE
+#  Format:                DWARF32
+#  Version:               4
+#  Augmentation:          "[llvm:v0.0]"
+#  Address size:          8
+#  Segment desc size:     0
+#  Code alignment factor: 4
+#  Data alignment factor: 4
+#  Return address column: 16
+#
+#  DW_CFA_nop:
+#  DW_CFA_nop:
+#  DW_CFA_nop:
+#  DW_CFA_nop:
+#  DW_CFA_nop:
+#  DW_CFA_nop:
+#  DW_CFA_nop:
+#  DW_CFA_nop:
+#  DW_CFA_nop:
+#  DW_CFA_nop:
+...
+)");
+  // Parse the yaml object file.
+  ASSERT_THAT_EXPECTED(ExpectedFile, llvm::Succeeded());
+
+  auto module_sp = std::make_shared<Module>(ExpectedFile->moduleSpec());
+  SectionList *list = module_sp->GetSectionList();
+  ASSERT_NE(nullptr, list);
+
+  auto section_sp = list->FindSectionByType(eSectionTypeDWARFDebugFrame, false);
+  ASSERT_NE(nullptr, section_sp);
+
+  DWARFCallFrameInfo cfi(*module_sp->GetObjectFile(), section_sp,
+                         DWARFCallFrameInfo::DWARF);
+  auto cie_sp = ParseCIE(cfi);
+  ASSERT_NE(cie_sp, nullptr);
+  ASSERT_STREQ((const char *)cie_sp->augmentation, "[llvm:v0.0]");
+}
+
 // Test valid CIE markers in debug_frame DWARF32 format
 TEST_F(DWARFCallFrameInfoTest, ValidCIEMarkers_dwarf32) {
   auto ExpectedFile = TestFile::fromYaml(R"(
@@ -599,38 +651,6 @@ Symbols:
     Binding:         STB_GLOBAL
 ...
 )");
-  ASSERT_THAT_EXPECTED(ExpectedFile, llvm::Succeeded());
-
-  Machine:         EM_AMDGPU
-  Flags:           [ EF_AMDGPU_MACH_AMDGCN_GFX942 ]
-Sections:
-  - Name:            .debug_frame
-    Type:            SHT_PROGBITS
-    AddressAlign:    0x0000000000000008
-    Content:         20000000FFFFFFFF045B6C6C766D3A76302E305D00080004041000000000000000000000
-#00000000 00000020 ffffffff CIE
-#  Format:                DWARF32
-#  Version:               4
-#  Augmentation:          "[llvm:v0.0]"
-#  Address size:          8
-#  Segment desc size:     0
-#  Code alignment factor: 4
-#  Data alignment factor: 4
-#  Return address column: 16
-#
-#  DW_CFA_nop:
-#  DW_CFA_nop:
-#  DW_CFA_nop:
-#  DW_CFA_nop:
-#  DW_CFA_nop:
-#  DW_CFA_nop:
-#  DW_CFA_nop:
-#  DW_CFA_nop:
-#  DW_CFA_nop:
-#  DW_CFA_nop:
-...
-)");
-  // Parse the yaml object file.
   ASSERT_THAT_EXPECTED(ExpectedFile, llvm::Succeeded());
   auto module_sp = std::make_shared<Module>(ExpectedFile->moduleSpec());
   SectionList *list = module_sp->GetSectionList();
@@ -704,14 +724,4 @@ Symbols:
   // Should succeed with valid CIE and FDE
   ASSERT_NE(nullptr, plan_up);
   EXPECT_GE(plan_up->GetRowCount(), 1);
-  // Grab the .debug_frame section.
-  auto section_sp = list->FindSectionByType(eSectionTypeDWARFDebugFrame, false);
-  ASSERT_NE(nullptr, section_sp);
-
-  // Make sure the augmentation string is parsed correctly.
-  DWARFCallFrameInfo cfi(*module_sp->GetObjectFile(), section_sp,
-                         DWARFCallFrameInfo::DWARF);
-  auto cie_sp = ParseCIE(cfi);
-  ASSERT_NE(cie_sp, nullptr);
-  ASSERT_STREQ((const char *)cie_sp->augmentation, "[llvm:v0.0]");
 }


### PR DESCRIPTION
 Two commits fixing compilation failures introduced by API changes that weren't reflected in the unit tests.

1. d6f5075dba3c added `addr_space` to `DWARFExpression::Evaluate` and `SymbolFile::MakeType` without updating the affected tests in `DWARFExpressionTest.cpp` and `LineTableTest.cpp`.

2. f9b95f8f6e13 accidentally nested `TEST_F(AugmentationString)` inside `TEST_F(ValidCIEMarkers_eh_frame)` instead of as a sibling test, causing a cascade of compilation errors in `TestDWARFCallFrameInfo.cpp`.