### PR TITLE
[LLDB][NVGPU] Fix test assertions to match actual Warp Assert exception string

### DIFF
--- a/lldb/test/API/gpu/nvidia/assert/TestNVGPUAssert.py
+++ b/lldb/test/API/gpu/nvidia/assert/TestNVGPUAssert.py
@@ -19,12 +19,12 @@ class TestNVGPUAssert(NVGPUTestCaseBase):
         self.continue_cpu_and_wait_for_gpu_to_stop()
 
         self.assertEqual(self.gpu_process.state, lldb.eStateStopped)
-        self.assertIn("CUDA Exception(12): Warp - Assert", str(self.gpu_process.thread[0]))
+        self.assertIn("CUDA Exception(12): Warp Assert", str(self.gpu_process.thread[0]))
 
         frame = self.gpu_process.thread[0].frame[0]
 
         # We don't expect to see an errorpc set
-        self.assertNotIn("CUDA Exception(12): Warp - Assert at 0x", str(self.gpu_process.thread[0]))
+        self.assertNotIn("CUDA Exception(12): Warp Assert at 0x", str(self.gpu_process.thread[0]))
         errorpc = frame.FindRegister("errorpc").GetValueAsAddress()
         self.assertEqual(errorpc, lldb.LLDB_INVALID_ADDRESS)
 

--- a/lldb/test/API/gpu/nvidia/disass/TestNVGPUDisass.py
+++ b/lldb/test/API/gpu/nvidia/disass/TestNVGPUDisass.py
@@ -42,7 +42,7 @@ class TestNVGPUDisass(NVGPUTestCaseBase):
         self.continue_cpu_and_wait_for_gpu_to_stop()
 
         self.assertEqual(self.gpu_process.state, lldb.eStateStopped)
-        self.assertIn("CUDA Exception(12): Warp - Assert", str(self.gpu_process.thread[0]))
+        self.assertIn("CUDA Exception(12): Warp Assert", str(self.gpu_process.thread[0]))
 
         # Now let's test that the disass can print at least one entry
         self.expect("disassemble", patterns=[".*cuda_elf.*\\.cubin`.*:.*"])


### PR DESCRIPTION
Test were failing since it was excepting `wrap Assert` but was getting `wrap - Assert`.