### PR TITLE
[LLDB][NVGPU] Fix memory read --space option incorrectly required and null ptr check broken by addr_space work

### DIFF
--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -815,7 +815,7 @@ let Command = "memory read" in {
         Groups<[1, 2, 3]>,
         Desc<"Necessary if reading over target.max-memory-read-size bytes.">;
   def memory_space : Option<"space", "p">, Groups<[1,2,3,4]>, Arg<"Name">,
-    Required, Desc<"The name of the address space to read from.">;
+    Desc<"The name of the address space to read from.">;
 }
 
 let Command = "memory find" in {

--- a/lldb/source/ValueObject/ValueObjectChild.cpp
+++ b/lldb/source/ValueObject/ValueObjectChild.cpp
@@ -159,7 +159,9 @@ bool ValueObjectChild::UpdateValue() {
         std::optional<uint64_t> address_space = parent->GetValue().GetAddressSpaceId();
         if (addr == LLDB_INVALID_ADDRESS) {
           m_error = Status::FromErrorString("parent address is invalid.");
-        } else if (addr == 0 && !address_space) {
+        } else if (addr == 0 &&
+                   (!address_space ||
+                    *address_space == LLDB_DEFAULT_ADDRESS_SPACE)) {
           m_error = Status::FromErrorString("parent is NULL");
         } else {
           // If a bitfield doesn't fit into the child_byte_size'd window at


### PR DESCRIPTION
Two regressions introduced by the `addr_space` work:

1) `Options.td` - `--space` option marked Required: The new `--space/-p` flag for reading from GPU address spaces was accidentally declared Required in all 4 option groups, meaning every memory read call without `--space` failed validation with `"invalid combination of options"`. Fixed by removing Required since it's optional, only needed for GPU address space reads.

2) `ValueObjectChild.cpp` - null pointer check bypassed: `SetValueType(LoadAddress)` now auto-initializes `m_addr_space_id = 0` (default space). The null check `addr == 0 && !address_space` was comparing against `nullopt`, but now address_space is always `{0}` so the check never fired, null pointer children fell through to actually reading from `0x0`. Fixed by also triggering the null check when address_space is the default `(0)`.