### PR TITLE
[LLDB][NVGPU] Fix Process is not being traced error message capitalization

### DIFF
--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -255,7 +255,7 @@ bool CommandObject::CheckRequirements(CommandReturnObject &result) {
   if (GetFlags().Test(eCommandProcessMustBeTraced)) {
     Target *target = m_exe_ctx.GetTargetPtr();
     if (target && !target->GetTrace()) {
-      result.AppendError("process is not being traced");
+      result.AppendError("Process is not being traced");
       return false;
     }
   }


### PR DESCRIPTION
tests were failing with:
```
Got output:
error: process is not being traced
Expecting sub string: "error: Process is not being traced" (was not found)
```

Seems like it's expecting capital `P`