### PR TITLE
[lldb] Fix GPU dynamic loader slice loading and section load tracking

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -154,12 +154,14 @@ Module::Module(const ModuleSpec &module_spec)
   if (data_sp)
     file_size = data_sp->GetByteSize();
 
-  // Slice-backed callers already describe the exact subobject they want. Plain
-  // file lookups still need whole-file enumeration so container plugins can
-  // contribute every member or slice before we pick the matching spec.
+  // Slice-backed callers already describe the exact subobject they want,
+  // whether the bytes come from memory or from a slice of a file on disk. A
+  // named object is an archive member: its offset points into the archive,
+  // which only parses from the start, so those still enumerate the whole file
+  // and are picked out by name below.
   ModuleSpecList modules_specs;
   const bool use_explicit_bounds =
-      data_sp && module_spec.HasObjectFileBounds();
+      module_spec.HasObjectFileBounds() && !module_spec.GetObjectName();
   const auto module_offset =
       use_explicit_bounds ? module_spec.GetObjectOffset() : 0;
   const auto module_size =

--- a/lldb/source/Plugins/DynamicLoader/GDBRemoteGPU/DynamicLoaderGDBRemoteGPU.cpp
+++ b/lldb/source/Plugins/DynamicLoader/GDBRemoteGPU/DynamicLoaderGDBRemoteGPU.cpp
@@ -15,6 +15,7 @@
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include "llvm/ADT/StringExtras.h"
 
 #include "DynamicLoaderGDBRemoteGPU.h"
 #include "Plugins/Process/gdb-remote/ProcessGDBRemote.h"
@@ -185,11 +186,11 @@ bool DynamicLoaderGDBRemoteGPU::LoadModulesFromGDBServer(bool full) {
           if (section_sp) {
             LLDB_LOG(log, "Loading module \"{0}\" section \"{1} to {2:x}",
                      info.pathname, section_sp->GetName(), sect.load_address);
-            changed = target.SetSectionLoadAddress(
+            changed |= target.SetSectionLoadAddress(
                 section_sp, sect.load_address, warn_multiple);
           } else {
             LLDB_LOG(log, "Failed to find section \"{0}\"",
-                     section_sp->GetName());
+                     llvm::join(sect.names, "."));
           }
         }
       } else {

--- a/lldb/test/API/python_api/module_slice/TestModuleSlice.py
+++ b/lldb/test/API/python_api/module_slice/TestModuleSlice.py
@@ -1,0 +1,106 @@
+"""
+Test adding a module that is a slice of a containing file.
+
+A HIP binary carries its device code inside a section of the host executable,
+and the GPU driver reports that code object to the debugger as a file path plus
+a byte offset and size. A ModuleSpec with an object offset/size has to read the
+embedded object rather than the containing file.
+"""
+
+import binascii
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+# A host executable carrying a device code object in a .hip_fatbin section.
+FAT_BINARY_YAML = """\
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1000
+    AddressAlign:    0x1000
+    Content:         "c3"
+  - Name:            .hip_fatbin
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC ]
+    AddressAlign:    0x1000
+    Content:         "%s"
+"""
+
+
+class ModuleSliceTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def make_gpu_code_object(self):
+        path = self.getBuildArtifact("gpu_code_object.so")
+        self.yaml2obj("gpu_code_object.yaml", path)
+        return path
+
+    def make_fat_binary(self, gpu_path):
+        """Embed the device code object in a .hip_fatbin section of a host
+        executable, the way a HIP binary carries it."""
+        with open(gpu_path, "rb") as f:
+            content = binascii.hexlify(f.read()).decode()
+        yaml_path = self.getBuildArtifact("fat_binary.yaml")
+        with open(yaml_path, "w") as f:
+            f.write(FAT_BINARY_YAML % content)
+        container = self.getBuildArtifact("fat_binary")
+        self.yaml2obj(yaml_path, container)
+        return container
+
+    def fatbin_section_range(self, container):
+        """Locate the embedded code object by the bounds of its section."""
+        target = self.dbg.CreateTarget("")
+        spec = lldb.SBModuleSpec()
+        spec.SetFileSpec(lldb.SBFileSpec(container))
+        module = target.AddModule(spec)
+        self.assertTrue(module.IsValid(), "the host executable should load")
+
+        section = module.FindSection(".hip_fatbin")
+        self.assertTrue(section.IsValid(), "host binary should have .hip_fatbin")
+        offset, size = section.GetFileOffset(), section.GetFileByteSize()
+        self.dbg.DeleteTarget(target)
+        return offset, size
+
+    def text_file_address(self, module):
+        section = module.FindSection(".text")
+        self.assertTrue(section.IsValid(), "module should have a .text section")
+        return section.GetFileAddress()
+
+    def test_code_object_in_fat_binary(self):
+        """The code object inside a .hip_fatbin section is read, not the host."""
+        gpu = self.make_gpu_code_object()
+        container = self.make_fat_binary(gpu)
+        offset, size = self.fatbin_section_range(container)
+
+        target = self.dbg.CreateTarget("")
+        spec = lldb.SBModuleSpec()
+        spec.SetFileSpec(lldb.SBFileSpec(container))
+        spec.SetObjectOffset(offset)
+        spec.SetObjectSize(size)
+
+        module = target.AddModule(spec)
+        self.assertTrue(module.IsValid(), "the code object should load")
+        # The device code object has .text at 0x3000, the host at 0x1000.
+        self.assertEqual(self.text_file_address(module), 0x3000)
+
+    def test_whole_file(self):
+        """Without an object offset the containing file itself is read."""
+        gpu = self.make_gpu_code_object()
+        container = self.make_fat_binary(gpu)
+
+        target = self.dbg.CreateTarget("")
+        spec = lldb.SBModuleSpec()
+        spec.SetFileSpec(lldb.SBFileSpec(container))
+
+        module = target.AddModule(spec)
+        self.assertTrue(module.IsValid(), "the host executable should load")
+        self.assertEqual(self.text_file_address(module), 0x1000)

--- a/lldb/test/API/python_api/module_slice/gpu_code_object.yaml
+++ b/lldb/test/API/python_api/module_slice/gpu_code_object.yaml
@@ -1,0 +1,20 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x3000
+    AddressAlign:    0x1000
+    Content:         "c3"
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    VAddr:           0x3000
+    Align:           0x1000
+    FirstSec:        .text
+    LastSec:         .text


### PR DESCRIPTION
 Couple of fixes for the module loading logic.
 
 1. Slice loading (Module.cpp) — the gate was data_sp && HasObjectFileBounds(), so a code object described by file_offset/file_size
  alone was ignored and the containing file got loaded. data_sp is only set for memory:// URIs, never file://. Now just
  HasObjectFileBounds().
  2. changed |= (DynamicLoaderGDBRemoteGPU.cpp) — was =, so a module whose last section didn't move was dropped from the loaded list
  even if an earlier one did.
  3. Null deref (same file) — the "failed to find section" log called section_sp->GetName() on the branch where section_sp is null by
  construction. Logs the requested names instead.