### PR TITLE
[compiler-rt][sanitizer] Backport removal of linux/scc.h

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
@@ -151,16 +151,15 @@ typedef struct user_fpregs elf_fpregset_t;
 #if defined(__mips64)
 # include <sys/procfs.h>
 #endif
-#include <sys/user.h>
-#include <linux/if_eql.h>
-#include <linux/if_plip.h>
-#include <linux/lp.h>
-#include <linux/mroute.h>
-#include <linux/mroute6.h>
-#include <linux/scc.h>
-#include <linux/serial.h>
-#include <sys/msg.h>
-#include <sys/ipc.h>
+#      include <linux/if_eql.h>
+#      include <linux/if_plip.h>
+#      include <linux/lp.h>
+#      include <linux/mroute.h>
+#      include <linux/mroute6.h>
+#      include <linux/serial.h>
+#      include <sys/ipc.h>
+#      include <sys/msg.h>
+#      include <sys/user.h>
 #endif  // SANITIZER_ANDROID
 
 #include <link.h>
@@ -532,8 +531,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
   unsigned struct_kbsentry_sz = sizeof(struct kbsentry);
   unsigned struct_mtconfiginfo_sz = sizeof(struct mtconfiginfo);
   unsigned struct_nr_parms_struct_sz = sizeof(struct nr_parms_struct);
-  unsigned struct_scc_modem_sz = sizeof(struct scc_modem);
-  unsigned struct_scc_stat_sz = sizeof(struct scc_stat);
   unsigned struct_serial_multiport_struct_sz
       = sizeof(struct serial_multiport_struct);
   unsigned struct_serial_struct_sz = sizeof(struct serial_struct);


### PR DESCRIPTION
## Summary

Backport llvm/llvm-project@3dc4fd6dd41100f051a63642f449b16324389c96 (#194116) to `llvm-server-plugins`.

Linux removed `<linux/scc.h>`, but this branch still includes it and declares sizes for `struct scc_modem` and `struct scc_stat`. This causes compiler-rt builds to fail on systems whose kernel headers no longer provide the header.

This applies the upstream one-file change unchanged and preserves its provenance with `cherry-pick -x`.

Upstream commit: https://github.com/llvm/llvm-project/commit/3dc4fd6dd41100f051a63642f449b16324389c96
Release/22 backport: https://github.com/llvm/llvm-project/commit/9b722024f1be0a5238147ec28ae45f0990a853ac

## Testing

- [x] Run the downstream ROClldb release gate against this patch: Release toolchain build, `check-lldb`, and expected-failure filtering all passed. The suite discovered 33,762 tests; 33,249 passed, and the remaining failures matched the existing baseline.
- [x] Build the Release+Distribution toolchain on Linux (`ninja distribution`).
- [x] Build compiler-rt with `/usr/include/linux/scc.h` masked as absent. The affected sanitizer source and all compiler-rt libraries built successfully. Six container privilege failures passed when rerun privileged; one unrelated LSan `release_to_os_test.cpp` assertion remained.
- [x] Build the Debug LLDB toolchain and compiler-rt runtimes (`lldb`, `lldb-server`, `lldb-dap`, and `runtimes`).
- [x] Run `LLDBServerAMDGPUPluginTests`: 12/12 passed.

A separate host-local `check-lldb` run was not green because the host mixed system, platform, and ROCm runtime libraries. Those loader failures did not reproduce in the downstream release environment, where the expected-failure filter passed.